### PR TITLE
ChangeLogGen - support requiredLabel, improve filename

### DIFF
--- a/ChangelogGenerator/ChangelogGenerator/Program.cs
+++ b/ChangelogGenerator/ChangelogGenerator/Program.cs
@@ -23,7 +23,7 @@ namespace ChangelogGenerator
         [Option('m', "Milestone", Required = true, HelpText = "Milestone to get issues from")]
         public string Milestone { get; set; }
 
-        [Option('l', "RequiredLabel", Required = true, HelpText = "Hide all issues without this label")]
+        [Option('l', "RequiredLabel", Required = true, HelpText = "Show only those issues from the selected milestone that have this label")]
         public string RequiredLabel { get; set; }
 
         [Option('v', null, HelpText = "Print details during execution.")]

--- a/ChangelogGenerator/ChangelogGenerator/Program.cs
+++ b/ChangelogGenerator/ChangelogGenerator/Program.cs
@@ -25,7 +25,7 @@ namespace ChangelogGenerator
 
         [Option('l', "RequiredLabel", Required = true, HelpText = "Hide all issues without this label")]
         public string RequiredLabel { get; set; }
-               
+
         [Option('v', null, HelpText = "Print details during execution.")]
         public bool Verbose { get; set; }
 
@@ -81,22 +81,27 @@ namespace ChangelogGenerator
         {
             try
             {
-                var issueFilter = new RepositoryIssueRequest()
+                RepositoryIssueRequest issueQuery;
+
+                if (options.IncludeOpen == "Y")
                 {
-                    Filter = IssueFilter.All,
-                    //Creator = "*",
-                    //Milestone = options.Milestone,
-                    State = ItemStateFilter.Closed,
-                    //Since = new DateTimeOffset(new DateTime(2013, 1, 1)),
-                  //  State = options.IncludeOpen.ToLower() == "y" ? ItemStateFilter.All : ItemStateFilter.Closed,
-                };
-                if (!string.IsNullOrEmpty(options.RequiredLabel))
+                    issueQuery = new RepositoryIssueRequest
+                    {
+                        Filter = IssueFilter.All,
+                        State = ItemStateFilter.All,
+                    };
+                }
+                else
                 {
-                  //  issueFilter.Labels.Add(options.RequiredLabel);
+                    issueQuery = new RepositoryIssueRequest
+                    {
+                        Filter = IssueFilter.All,
+                        State = ItemStateFilter.Closed,
+                    };
                 }
 
-                var issues = await client.Issue.GetAllForRepository(options.Organization, options.Repo, issueFilter);
-                
+                var issues = await client.Issue.GetAllForRepository(options.Organization, options.Repo, issueQuery);
+
                 Dictionary<IssueType, List<Issue>> IssuesByIssueType = new Dictionary<IssueType, List<Issue>>();
                 foreach (var issue in issues)
                 {
@@ -235,7 +240,7 @@ namespace ChangelogGenerator
                 }
             }
 
-            var fileName = "Changelog-" + options.Milestone 
+            var fileName = "Changelog-" + options.Milestone
                 + (string.IsNullOrEmpty(options.RequiredLabel) ? "" : "-" + options.RequiredLabel) + ".md";
             File.WriteAllText(fileName, builder.ToString());
             Console.WriteLine($"{fileName} creation complete");

--- a/ChangelogGenerator/ChangelogGenerator/Program.cs
+++ b/ChangelogGenerator/ChangelogGenerator/Program.cs
@@ -235,7 +235,8 @@ namespace ChangelogGenerator
                 }
             }
 
-            var fileName = "Changelog-" + options.Milestone + (string.IsNullOrEmpty(options.RequiredLabel) ? "" : options.RequiredLabel) + ".md";
+            var fileName = "Changelog-" + options.Milestone 
+                + (string.IsNullOrEmpty(options.RequiredLabel) ? "" : "-" + options.RequiredLabel) + ".md";
             File.WriteAllText(fileName, builder.ToString());
             Console.WriteLine($"{fileName} creation complete");
             Environment.Exit(0);


### PR DESCRIPTION
- New command line param: "-l Preview2" allows you to do a required label. So you could search for 5.0-preview2 issues via milestone and label.
- output filename is now Changelog-5.0-Preview2.md if you have a milestone and required label set.
- renamed labelSet to IssuesByIssueType
- removed problemIssues -- as they all showed up as "None" items in the output anyway.
