### PR TITLE
Make probe ranges configurable

### DIFF
--- a/SearchScorer/SearchScorer/Common/SearchProbesCsvWriter.cs
+++ b/SearchScorer/SearchScorer/Common/SearchProbesCsvWriter.cs
@@ -6,7 +6,7 @@ namespace SearchScorer.Common
 {
     public static class SearchProbesCsvWriter
     {
-        public static void Write(string path, SearchProbesRecord score)
+        public static void Append(string path, SearchProbesRecord score)
         {
             var exists = File.Exists(path);
 

--- a/SearchScorer/SearchScorer/Common/SearchProbesCsvWriter.cs
+++ b/SearchScorer/SearchScorer/Common/SearchProbesCsvWriter.cs
@@ -6,15 +6,21 @@ namespace SearchScorer.Common
 {
     public static class SearchProbesCsvWriter
     {
-        public static void Write(string path, IEnumerable<SearchProbesRecord> scores)
+        public static void Write(string path, SearchProbesRecord score)
         {
-            using (var fileStream = new FileStream(path, FileMode.Create))
-            using (var streamWriter = new StreamWriter(fileStream))
+            var exists = File.Exists(path);
+
+            using (var streamWriter = new StreamWriter(path, append: true))
             using (var csvWriter = new CsvWriter(streamWriter))
             {
-                csvWriter.WriteHeader<SearchProbesRecord>();
-                csvWriter.NextRecord();
-                csvWriter.WriteRecords(scores);
+                if (!exists)
+                {
+                    csvWriter.WriteHeader<SearchProbesRecord>();
+                    csvWriter.NextRecord();
+                }
+
+                csvWriter.WriteRecord(score);
+                streamWriter.WriteLine();
             }
         }
     }

--- a/SearchScorer/SearchScorer/Program.cs
+++ b/SearchScorer/SearchScorer/Program.cs
@@ -37,8 +37,8 @@ namespace SearchScorer
                 GitHubUsageCsvPath = @"C:\Users\jver\Desktop\search-scorer\GitHubUsage.v1-2019-08-06.csv",
 
                 // The following settings are only necessary if running the "probe" command.
-                AzureSearchServiceName = "nuget-prod-usnc-perf",
-                AzureSearchIndexName = "search-perf-000",
+                AzureSearchServiceName = "",
+                AzureSearchIndexName = "",
                 AzureSearchApiKey = "",
                 ProbeResultsCsvPath = @"C:\Users\jver\Desktop\search-scorer\ProbeResults.csv",
 

--- a/SearchScorer/SearchScorer/Program.cs
+++ b/SearchScorer/SearchScorer/Program.cs
@@ -101,7 +101,7 @@ namespace SearchScorer
                     customVariantUrl: settings.TreatmentBaseUrl);
 
                 // Save the result to the output path
-                SearchProbesCsvWriter.Write(
+                SearchProbesCsvWriter.Append(
                     settings.ProbeResultsCsvPath,
                     new SearchProbesRecord
                     {
@@ -141,12 +141,13 @@ namespace SearchScorer
                 });
         }
 
-        private static IEnumerable<double> CreateRange(int lower, int upper, double increments)
+        private static IReadOnlyList<double> CreateRange(int lower, int upper, double increments)
         {
             var count = (upper - lower) / increments + 1;
             return Enumerable
                 .Range(0, (int)count)
-                .Select(i => (i * increments + lower));
+                .Select(i => (i * increments + lower))
+                .ToList();
         }
 
         // From: https://codereview.stackexchange.com/questions/122699/finding-a-cartesian-product-of-multiple-lists

--- a/SearchScorer/SearchScorer/SearchScorerSettings.cs
+++ b/SearchScorer/SearchScorer/SearchScorerSettings.cs
@@ -23,9 +23,9 @@ namespace SearchScorer
         public string AzureSearchIndexName { get; set; }
         public string AzureSearchApiKey { get; set; }
 
-        public IEnumerable<double> PackageIdWeights { get; set; }
-        public IEnumerable<double> TokenizedPackageIdWeights { get; set; }
-        public IEnumerable<double> TagsWeights { get; set; }
-        public IEnumerable<double> DownloadWeights { get; set; }
+        public IReadOnlyList<double> PackageIdWeights { get; set; }
+        public IReadOnlyList<double> TokenizedPackageIdWeights { get; set; }
+        public IReadOnlyList<double> TagsWeights { get; set; }
+        public IReadOnlyList<double> DownloadWeights { get; set; }
     }
 }

--- a/SearchScorer/SearchScorer/SearchScorerSettings.cs
+++ b/SearchScorer/SearchScorer/SearchScorerSettings.cs
@@ -1,4 +1,7 @@
-﻿namespace SearchScorer
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace SearchScorer
 {
     public class SearchScorerSettings
     {
@@ -19,5 +22,10 @@
         public string AzureSearchServiceName { get; set; }
         public string AzureSearchIndexName { get; set; }
         public string AzureSearchApiKey { get; set; }
+
+        public IEnumerable<double> PackageIdWeights { get; set; }
+        public IEnumerable<double> TokenizedPackageIdWeights { get; set; }
+        public IEnumerable<double> TagsWeights { get; set; }
+        public IEnumerable<double> DownloadWeights { get; set; }
     }
 }


### PR DESCRIPTION
For instructions, see the [Run the search prober tool](https://microsoft.sharepoint.com/teams/NuGet/_layouts/OneNote.aspx?id=%2Fteams%2FNuGet%2FTeam%2FNugetServer%2FNugetServerTeamNote&wd=target%28Operations.one%7CC674B49C-4CB7-4793-8890-A1E46E33FEB9%2FEvaluating%20search%20relevancy%20changes%7CE8C70D86-10CB-441A-BDD5-02317F02F18F%2F%29onenote:https://microsoft.sharepoint.com/teams/NuGet/Team/NugetServer/NugetServerTeamNote/Operations.one#Evaluating%20search%20relevancy%20changes&section-id={C674B49C-4CB7-4793-8890-A1E46E33FEB9}&page-id={E8C70D86-10CB-441A-BDD5-02317F02F18F}&object-id={94027662-4114-0D1E-077E-5049CB61DD40}&82) guide on OneNote.