### PR TITLE
nuget-sdk-usage initial NuGet.Client source updating

### DIFF
--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningConstructor/Class1.cs
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningConstructor/Class1.cs
@@ -1,0 +1,12 @@
+﻿using NuGet.Versioning;
+
+namespace NuGetVersioningConstructor
+{
+    public class Class1
+    {
+        public void Method()
+        {
+            new SemanticVersion(1, 0, 0);
+        }
+    }
+}

--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningConstructor/NuGetVersioningConstructor.csproj
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningConstructor/NuGetVersioningConstructor.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" Version="5.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningOperators/Class1.cs
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningOperators/Class1.cs
@@ -1,0 +1,24 @@
+﻿using NuGet.Versioning;
+
+namespace NuGetVersioningOperators
+{
+    public class Class1
+    {
+        public int Method()
+        {
+            var v1 = NuGetVersion.Parse("1.0.0");
+            var v2 = NuGetVersion.Parse("2.0.0");
+
+            // Use variable to make sure compiler doesn't optimise away method call to operators.
+            int result = 0;
+            result += v1 == v2 ? 1 : 0;
+            result += v1 != v2 ? 1 : 0;
+            result += v1 > v2 ? 1 : 0;
+            result += v1 >= v2 ? 1 : 0;
+            result += v1 < v2 ? 1 : 0;
+            result += v1 <= v2 ? 1 : 0;
+
+            return result;
+        }
+    }
+}

--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningOperators/NuGetVersioningOperators.csproj
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningOperators/NuGetVersioningOperators.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" Version="5.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningOutParameter/Class1.cs
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningOutParameter/Class1.cs
@@ -1,0 +1,12 @@
+﻿using NuGet.Versioning;
+
+namespace NuGetVersioningOutParameter
+{
+    public class Class1
+    {
+        public void Method()
+        {
+            NuGetVersion.TryParse("1.2.3", out _);
+        }
+    }
+}

--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningOutParameter/NuGetVersioningOutParameter.csproj
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningOutParameter/NuGetVersioningOutParameter.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" Version="5.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningProperty/Class1.cs
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningProperty/Class1.cs
@@ -1,0 +1,9 @@
+﻿using NuGet.Versioning;
+
+namespace NuGetVersioningProperty
+{
+    public class Class1
+    {
+        public VersionRange All => VersionRange.All;
+    }
+}

--- a/nuget-sdk-usage/TestAssemblies/NuGetVersioningProperty/NuGetVersioningProperty.csproj
+++ b/nuget-sdk-usage/TestAssemblies/NuGetVersioningProperty/NuGetVersioningProperty.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" Version="5.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/nuget-sdk-usage/nuget-sdk-usage.Tests/Analysis/Assembly/TypeNameGeneratorTests.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage.Tests/Analysis/Assembly/TypeNameGeneratorTests.cs
@@ -1,0 +1,177 @@
+﻿using nuget_sdk_usage.Analysis.Assembly;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using Xunit;
+
+namespace nuget_sdk_usage.Tests.Analysis.Assembly
+{
+    public class TypeNameGeneratorTests
+    {
+        [Fact]
+        public void FindUsedNuGetApis_AssemblyUsesOperatorMethods_ReturnsCorrectOperatorMethodNames()
+        {
+            UsageInformation usageInformation;
+            using (var fileStream = File.OpenRead(typeof(NuGetVersioningOperators.Class1).Assembly.Location))
+            {
+                using (var peReader = new PEReader(fileStream))
+                {
+                    var metadata = peReader.GetMetadataReader();
+                    usageInformation = AssemblyAnalyser.FindUsedNuGetApis(metadata);
+                }
+            }
+
+            HashSet<string> expected = new HashSet<string>()
+            {
+                "NuGet.Versioning.NuGetVersion.Parse(string)",
+                "NuGet.Versioning.SemanticVersion.operator ==(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
+                "NuGet.Versioning.SemanticVersion.operator !=(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
+                "NuGet.Versioning.SemanticVersion.operator >(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
+                "NuGet.Versioning.SemanticVersion.operator >=(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
+                "NuGet.Versioning.SemanticVersion.operator <(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
+                "NuGet.Versioning.SemanticVersion.operator <=(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)"
+            };
+
+            var (assembly, memberReferences) = Assert.Single(usageInformation.MemberReferences);
+            Assert.Equal("NuGet.Versioning", assembly);
+            AssertHashSets(expected, memberReferences);
+        }
+
+        [Fact]
+        public void FindUsedNuGetApis_AssemblyUsesConstructor_ReturnsCorrectMethodNames()
+        {
+            UsageInformation usageInformation;
+            using (var fileStream = File.OpenRead(typeof(NuGetVersioningConstructor.Class1).Assembly.Location))
+            {
+                using (var peReader = new PEReader(fileStream))
+                {
+                    var metadata = peReader.GetMetadataReader();
+                    usageInformation = AssemblyAnalyser.FindUsedNuGetApis(metadata);
+                }
+            }
+
+            HashSet<string> expected = new HashSet<string>()
+            {
+                "NuGet.Versioning.SemanticVersion.SemanticVersion(int, int, int)"
+            };
+
+            var (assembly, memberReferences) = Assert.Single(usageInformation.MemberReferences);
+            Assert.Equal("NuGet.Versioning", assembly);
+            AssertHashSets(expected, memberReferences);
+        }
+
+        [Fact]
+        public void FindUsedNuGetApis_AssemblyUsesProperty_ReturnsCorrectName()
+        {
+            UsageInformation usageInformation;
+            using (var fileStream = File.OpenRead(typeof(NuGetVersioningProperty.Class1).Assembly.Location))
+            {
+                using (var peReader = new PEReader(fileStream))
+                {
+                    var metadata = peReader.GetMetadataReader();
+                    usageInformation = AssemblyAnalyser.FindUsedNuGetApis(metadata);
+                }
+            }
+
+            HashSet<string> expected = new HashSet<string>()
+            {
+                "NuGet.Versioning.VersionRange.All"
+            };
+
+            var (assembly, memberReferences) = Assert.Single(usageInformation.MemberReferences);
+            Assert.Equal("NuGet.Versioning", assembly);
+            AssertHashSets(expected, memberReferences);
+        }
+
+        [Fact]
+        public void FindUsedNuGetApis_AssemblyUsesOutParameter_ReturnsCorrectName()
+        {
+            UsageInformation usageInformation;
+            using (var fileStream = File.OpenRead(typeof(NuGetVersioningOutParameter.Class1).Assembly.Location))
+            {
+                using (var peReader = new PEReader(fileStream))
+                {
+                    var metadata = peReader.GetMetadataReader();
+                    usageInformation = AssemblyAnalyser.FindUsedNuGetApis(metadata);
+                }
+            }
+
+            HashSet<string> expected = new HashSet<string>()
+            {
+                "NuGet.Versioning.NuGetVersion.TryParse(string, out NuGet.Versioning.NuGetVersion)"
+            };
+
+            var (assembly, memberReferences) = Assert.Single(usageInformation.MemberReferences);
+            Assert.Equal("NuGet.Versioning", assembly);
+            AssertHashSets(expected, memberReferences);
+        }
+
+        private void AssertHashSets(HashSet<string> expected, HashSet<string> actual)
+        {
+            var missing = expected.ToHashSet();
+            var extra = actual.ToHashSet();
+
+            foreach (var value in expected)
+            {
+                extra.Remove(value);
+            }
+
+            foreach (var value in actual)
+            {
+                missing.Remove(value);
+            }
+
+            if (missing.Count > 0 || extra.Count > 0)
+            {
+                var sb = new StringBuilder();
+                if (missing.Count > 0)
+                {
+                    sb.Append("Missing: ");
+                    bool first = true;
+                    foreach (var value in missing)
+                    {
+                        if (first)
+                        {
+                            first = false;
+                        }
+                        else
+                        {
+                            sb.Append(", ");
+                        }
+
+                        sb.Append(value);
+                    }
+                }
+
+                if (extra.Count > 0)
+                {
+                    if (missing.Count > 0)
+                    {
+                        sb.AppendLine();
+                    }
+
+                    sb.Append("extra: ");
+                    bool first = true;
+                    foreach (var value in extra)
+                    {
+                        if (first)
+                        {
+                            first = false;
+                        }
+                        else
+                        {
+                            sb.Append(", ");
+                        }
+
+                        sb.Append(value);
+                    }
+                }
+
+                throw new System.Exception(sb.ToString());
+            }
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage.Tests/Updater/SourceUpdaterTests.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage.Tests/Updater/SourceUpdaterTests.cs
@@ -1,0 +1,375 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using nuget_sdk_usage.Updater;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace nuget_sdk_usage.Tests.Updater
+{
+    public class SourceUpdaterTests
+    {
+        [Theory]
+        [InlineData(SourceType.Constructor, SourceType.ConstructorWithAttribute, true)]
+        [InlineData(SourceType.ConstructorWithDoc, SourceType.ConstructorWithDocAndAttribute, true)]
+        [InlineData(SourceType.ConstructorWithAttribute, SourceType.Constructor, false)]
+        [InlineData(SourceType.ConstructorWithDocAndAttribute, SourceType.ConstructorWithDoc, false)]
+        public void Visit_Constructor(SourceType inputSource, SourceType expectedSource, bool add)
+        {
+            var input = GetSource(inputSource);
+            var expected = GetSource(expectedSource);
+            var memberName = "ClassLibrary1.Class1.Class1()";
+
+            var action = new KeyValuePair<string, UpdateAction>(memberName, new UpdateAction(add));
+
+            AssertAction(input, action, expected);
+        }
+
+        [Theory]
+        [InlineData(SourceType.Field, SourceType.FieldWithAttribute, true)]
+        [InlineData(SourceType.FieldWithDoc, SourceType.FieldWithDocAndAttribute, true)]
+        [InlineData(SourceType.FieldWithAttribute, SourceType.Field, false)]
+        [InlineData(SourceType.FieldWithDocAndAttribute, SourceType.FieldWithDoc, false)]
+        public void Visit_Field(SourceType inputSource, SourceType expectedSource, bool add)
+        {
+            var input = GetSource(inputSource);
+            var expected = GetSource(expectedSource);
+            var memberName = "ClassLibrary1.Class1.Field";
+
+            var action = new KeyValuePair<string, UpdateAction>(memberName, new UpdateAction(add));
+
+            AssertAction(input, action, expected);
+        }
+
+        [Theory]
+        [InlineData(SourceType.Method, SourceType.MethodWithAttribute, true)]
+        [InlineData(SourceType.MethodWithDoc, SourceType.MethodWithDocAndAttribute, true)]
+        [InlineData(SourceType.MethodWithAttribute, SourceType.Method, false)]
+        [InlineData(SourceType.MethodWithDocAndAttribute, SourceType.MethodWithDoc, false)]
+        public void Visit_Method(SourceType inputSource, SourceType expectedSource, bool add)
+        {
+            var input = GetSource(inputSource);
+            var expected = GetSource(expectedSource);
+            var memberName = "ClassLibrary1.Class1.Method()";
+
+            var action = new KeyValuePair<string, UpdateAction>(memberName, new UpdateAction(add));
+
+            AssertAction(input, action, expected);
+        }
+
+        [Theory]
+        [InlineData(SourceType.Property, SourceType.PropertyWithAttribute, true)]
+        [InlineData(SourceType.PropertyWithDoc, SourceType.PropertyWithDocAndAttribute, true)]
+        [InlineData(SourceType.PropertyWithAttribute, SourceType.Property, false)]
+        [InlineData(SourceType.PropertyWithDocAndAttribute, SourceType.PropertyWithDoc, false)]
+        public void Visit_Property(SourceType inputSource, SourceType expectedSource, bool add)
+        {
+            var input = GetSource(inputSource);
+            var expected = GetSource(expectedSource);
+            var memberName = "ClassLibrary1.Class1.Property";
+
+            var action = new KeyValuePair<string, UpdateAction>(memberName, new UpdateAction(add));
+
+            AssertAction(input, action, expected);
+        }
+
+        [Fact]
+        public void Visit_FieldWithAnotherAttribute()
+        {
+            var input = @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        [Obsolete]
+        public string Field;
+    }
+}";
+
+            var expected = @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        [Obsolete]
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public string Field;
+    }
+}";
+
+            var memberName = "ClassLibrary1.Class1.Field";
+
+            var action = new KeyValuePair<string, UpdateAction>(memberName, new UpdateAction(addAttribute: true));
+
+            AssertAction(input, action, expected);
+        }
+
+        private void AssertAction(string original, KeyValuePair<string, UpdateAction> action, string expected)
+        {
+            // Arrange
+            var syntaxTree = CSharpSyntaxTree.ParseText(original);
+            var assemblyName = Path.GetRandomFileName();
+            var references = new MetadataReference[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+            };
+
+            var compilation = CSharpCompilation.Create(
+                assemblyName,
+                syntaxTrees: new[] { syntaxTree, AttributeSyntax },
+                references: references,
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            var semanticModel = compilation.GetSemanticModel(syntaxTree, false);
+
+            var actions = new Dictionary<string, UpdateAction>()
+            {
+                { action.Key, action.Value }
+            };
+
+            var target = new SourceUpdater(actions, semanticModel);
+
+            // Act
+            var result = target.Visit(syntaxTree.GetRoot());
+
+            // Assert
+            Assert.True(action.Value.Actioned);
+
+            var text = result.ToFullString();
+            Assert.Equal(expected, text);
+        }
+
+        private static readonly SyntaxTree AttributeSyntax = CSharpSyntaxTree.ParseText(@"
+namespace NuGet.Shared
+{
+    public class UsedNuGetSdkApiAttribute : Attribute
+    {
+    }
+}
+");
+
+        public enum SourceType
+        {
+            Constructor,
+            ConstructorWithAttribute,
+            ConstructorWithDoc,
+            ConstructorWithDocAndAttribute,
+            Field,
+            FieldWithAttribute,
+            FieldWithDoc,
+            FieldWithDocAndAttribute,
+            Method,
+            MethodWithAttribute,
+            MethodWithDoc,
+            MethodWithDocAndAttribute,
+            Property,
+            PropertyWithAttribute,
+            PropertyWithDoc,
+            PropertyWithDocAndAttribute,
+        }
+
+        private string GetSource(SourceType sourceType)
+        {
+            return sourceType switch
+            {
+                SourceType.Constructor => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        public Class1()
+        {
+        }
+    }
+}",
+
+                SourceType.ConstructorWithAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public Class1()
+        {
+        }
+    }
+}",
+
+                SourceType.ConstructorWithDoc => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        public Class1()
+        {
+        }
+    }
+}",
+
+                SourceType.ConstructorWithDocAndAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public Class1()
+        {
+        }
+    }
+}",
+
+                SourceType.Field => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        public string Field;
+    }
+}",
+
+                SourceType.FieldWithAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public string Field;
+    }
+}",
+
+                SourceType.FieldWithDoc => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        public string Field;
+    }
+}",
+
+                SourceType.FieldWithDocAndAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public string Field;
+    }
+}",
+
+                SourceType.Method => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        public void Method()
+        {
+        }
+    }
+}",
+
+                SourceType.MethodWithAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public void Method()
+        {
+        }
+    }
+}",
+
+                SourceType.MethodWithDoc => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        public void Method()
+        {
+        }
+    }
+}",
+
+                SourceType.MethodWithDocAndAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public void Method()
+        {
+        }
+    }
+}",
+
+                SourceType.Property => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        public int Property { get; set; }
+    }
+}",
+
+                SourceType.PropertyWithAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public int Property { get; set; }
+    }
+}",
+
+                SourceType.PropertyWithDoc => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        public int Property { get; set; }
+    }
+}",
+
+                SourceType.PropertyWithDocAndAttribute => @"using System;
+
+namespace ClassLibrary1
+{
+    class Class1
+    {
+        /// <Summary>Doc</Summary>
+        [NuGet.Shared.UsedNuGetSdkApi]
+        public int Property { get; set; }
+    }
+}",
+
+                _ => throw new NotImplementedException(sourceType.ToString())
+            };
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage.Tests/nuget-sdk-usage.Tests.csproj
+++ b/nuget-sdk-usage/nuget-sdk-usage.Tests/nuget-sdk-usage.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>nuget_sdk_usage.Tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NuGet.Versioning" Version="5.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nuget-sdk-usage\nuget-sdk-usage.csproj" />
+    <ProjectReference Include="..\TestAssemblies\**\*.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nuget-sdk-usage/nuget-sdk-usage.sln
+++ b/nuget-sdk-usage/nuget-sdk-usage.sln
@@ -10,6 +10,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		readme.md = readme.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nuget-sdk-usage.Tests", "nuget-sdk-usage.Tests\nuget-sdk-usage.Tests.csproj", "{463A413F-285D-47A2-9976-400AFF000B20}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestAssemblies", "TestAssemblies", "{F40C795D-DD38-48D4-AA94-0B41BDA1261A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetVersioningOperators", "TestAssemblies\NuGetVersioningOperators\NuGetVersioningOperators.csproj", "{83DCCC3B-3763-49DE-9273-B5D7CD4212B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetVersioningOutParameter", "TestAssemblies\NuGetVersioningOutParameter\NuGetVersioningOutParameter.csproj", "{6FE6F087-65C2-463B-BFF4-151994CEE93D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetVersioningConstructor", "TestAssemblies\NuGetVersioningConstructor\NuGetVersioningConstructor.csproj", "{2E507191-C137-43CA-990E-7F2E65A065C3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetVersioningProperty", "TestAssemblies\NuGetVersioningProperty\NuGetVersioningProperty.csproj", "{2FD784EF-9953-4D23-80A6-E5D4320A1612}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,9 +32,35 @@ Global
 		{896D0836-C69C-4E21-AFC0-857B99D4C441}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{896D0836-C69C-4E21-AFC0-857B99D4C441}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{896D0836-C69C-4E21-AFC0-857B99D4C441}.Release|Any CPU.Build.0 = Release|Any CPU
+		{463A413F-285D-47A2-9976-400AFF000B20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463A413F-285D-47A2-9976-400AFF000B20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463A413F-285D-47A2-9976-400AFF000B20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463A413F-285D-47A2-9976-400AFF000B20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83DCCC3B-3763-49DE-9273-B5D7CD4212B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83DCCC3B-3763-49DE-9273-B5D7CD4212B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83DCCC3B-3763-49DE-9273-B5D7CD4212B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83DCCC3B-3763-49DE-9273-B5D7CD4212B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FE6F087-65C2-463B-BFF4-151994CEE93D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FE6F087-65C2-463B-BFF4-151994CEE93D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FE6F087-65C2-463B-BFF4-151994CEE93D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FE6F087-65C2-463B-BFF4-151994CEE93D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E507191-C137-43CA-990E-7F2E65A065C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E507191-C137-43CA-990E-7F2E65A065C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E507191-C137-43CA-990E-7F2E65A065C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E507191-C137-43CA-990E-7F2E65A065C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FD784EF-9953-4D23-80A6-E5D4320A1612}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FD784EF-9953-4D23-80A6-E5D4320A1612}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FD784EF-9953-4D23-80A6-E5D4320A1612}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FD784EF-9953-4D23-80A6-E5D4320A1612}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{83DCCC3B-3763-49DE-9273-B5D7CD4212B7} = {F40C795D-DD38-48D4-AA94-0B41BDA1261A}
+		{6FE6F087-65C2-463B-BFF4-151994CEE93D} = {F40C795D-DD38-48D4-AA94-0B41BDA1261A}
+		{2E507191-C137-43CA-990E-7F2E65A065C3} = {F40C795D-DD38-48D4-AA94-0B41BDA1261A}
+		{2FD784EF-9953-4D23-80A6-E5D4320A1612} = {F40C795D-DD38-48D4-AA94-0B41BDA1261A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FA3EC6A5-A0B4-4318-BA6A-1FA22A02EF41}

--- a/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/MethodSignatureDecoder.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/MethodSignatureDecoder.cs
@@ -2,9 +2,9 @@
 using System.Reflection.Metadata;
 using System.Text;
 
-namespace nuget_sdk_usage
+namespace nuget_sdk_usage.Analysis.Assembly
 {
-    internal class MethodSignatureDecoder : ISignatureTypeProvider<string, object?>
+    internal class MethodSignatureDecoder : ISignatureTypeProvider<string, object>
     {
         public static MethodSignatureDecoder Default { get; } = new MethodSignatureDecoder();
 
@@ -15,7 +15,10 @@ namespace nuget_sdk_usage
 
         public string GetByReferenceType(string elementType)
         {
-            return elementType;
+            // I think IL doesn't have a difference between what C# calls `out` and `ref`. `out` is just `ref`
+            // with the convention that it always sets a value. Currently, NuGet.Client doesn't use `ref` in
+            // public APIs, but if it does one day, then nuget-sdk-usage needs to be updated to deal with it.
+            return "out " + elementType;
         }
 
         public string GetFunctionPointerType(MethodSignature<string> signature)
@@ -108,16 +111,16 @@ namespace nuget_sdk_usage
         }
 
 #pragma warning disable CS8601 // Possible null reference assignment.
-        private static readonly string BooleanName = typeof(bool).FullName;
-        private static readonly string StringName = typeof(string).FullName;
-        private static readonly string VoidName = typeof(void).FullName;
-        private static readonly string Int32Name = typeof(int).FullName;
-        private static readonly string ByteName = typeof(byte).FullName;
-        private static readonly string ObjectName = typeof(object).FullName;
-        private static readonly string Int64Name = typeof(long).FullName;
+        private static readonly string BooleanName = "bool";
+        private static readonly string StringName = "string";
+        private static readonly string VoidName = "void";
+        private static readonly string Int32Name = "int";
+        private static readonly string ByteName = "byte";
+        private static readonly string ObjectName = "object";
+        private static readonly string Int64Name = "long";
         private static readonly string IntPtrName = typeof(System.IntPtr).FullName;
-        private static readonly string DoubleName = typeof(double).FullName;
-        private static readonly string CharName = typeof(char).FullName;
+        private static readonly string DoubleName = "double";
+        private static readonly string CharName = "char";
 #pragma warning restore CS8601 // Possible null reference assignment.
     }
 }

--- a/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/NuGetAssembly.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/NuGetAssembly.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
 
-namespace nuget_sdk_usage
+namespace nuget_sdk_usage.Analysis.Assembly
 {
     internal static class NuGetAssembly
     {

--- a/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/TargetFrameworkAttributeDecoder.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/TargetFrameworkAttributeDecoder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection.Metadata;
 
-namespace nuget_sdk_usage
+namespace nuget_sdk_usage.Analysis.Assembly
 {
     internal class TargetFrameworkAttributeDecoder : ICustomAttributeTypeProvider<string>
     {

--- a/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/UsageInformation.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Analysis/Assembly/UsageInformation.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace nuget_sdk_usage
+namespace nuget_sdk_usage.Analysis.Assembly
 {
     internal class UsageInformation
     {

--- a/nuget-sdk-usage/nuget-sdk-usage/Analysis/Scanning/Scanner.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Analysis/Scanning/Scanner.cs
@@ -1,0 +1,191 @@
+﻿using nuget_sdk_usage.Analysis.Assembly;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace nuget_sdk_usage.Analysis.Scanning
+{
+    internal class Scanner
+    {
+        internal static Command GetCommand()
+        {
+            var command = new Command("scan")
+            {
+                new Argument<DirectoryInfo>("directory")
+                {
+                    Arity = ArgumentArity.ExactlyOne,
+                    Description = "The directory to scan"
+                },
+                new Option<FileInfo>("--output")
+            };
+
+            command.Handler = CommandHandler.Create(typeof(Scanner).GetMethod(nameof(InvokeAsync)));
+
+            return command;
+        }
+
+        public async Task InvokeAsync(DirectoryInfo directory, FileInfo output)
+        {
+            if (!directory.Exists)
+            {
+                Console.WriteLine("Directory \"" + directory.FullName + "\" does not exist");
+                return;
+            }
+
+            FileStream fileStream;
+            TextWriter textWriter;
+            if (output != null)
+            {
+                fileStream = output.OpenWrite();
+                textWriter = new StreamWriter(fileStream, encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize: 4 * 1024, leaveOpen: true);
+            }
+            else
+            {
+                fileStream = null;
+                textWriter = Console.Out;
+            }
+
+            var files =
+                directory.EnumerateFiles("*.dll", SearchOption.AllDirectories)
+                .Concat(directory.EnumerateFiles("*.exe", SearchOption.AllDirectories));
+
+            var usedApis = await GetUsageInformation(files);
+
+            if (fileStream != null)
+            {
+                fileStream.Position = 0;
+            }
+            WriteApiList(usedApis, textWriter);
+            textWriter.Flush();
+            textWriter.Dispose();
+            if (fileStream != null)
+            {
+                fileStream.Flush();
+                fileStream.SetLength(fileStream.Position);
+                fileStream.Dispose();
+            }
+        }
+
+        private static async Task<UsageInformation> GetUsageInformation(IEnumerable<FileInfo> files)
+        {
+            var result = new UsageInformation();
+
+            var multipleInstancesOption = new ExecutionDataflowBlockOptions
+            {
+                MaxDegreeOfParallelism = Environment.ProcessorCount
+            };
+            var singleInstanceOption = new ExecutionDataflowBlockOptions
+            {
+                MaxDegreeOfParallelism = 1
+            };
+
+            var getApisBlock = new TransformBlock<FileInfo, UsageInformation>(GetApisUsedByAssembly, multipleInstancesOption);
+            var collectApisBlock = new ActionBlock<UsageInformation>(assemblyInfo =>
+            {
+                if (assemblyInfo != null)
+                {
+                    foreach (var targetFramework in assemblyInfo.TargetFrameworks)
+                    {
+                        result.TargetFrameworks.Add(targetFramework);
+                    }
+
+                    foreach (var version in assemblyInfo.Versions)
+                    {
+                        result.Versions.Add(version);
+                    }
+
+                    foreach (var apisByAssembly in assemblyInfo.MemberReferences)
+                    {
+                        if (!result.MemberReferences.TryGetValue(apisByAssembly.Key, out HashSet<string> allApis))
+                        {
+                            allApis = new HashSet<string>();
+                            result.MemberReferences[apisByAssembly.Key] = allApis;
+                        }
+
+                        foreach (var api in apisByAssembly.Value)
+                        {
+                            allApis.Add(api);
+                        }
+                    }
+                }
+            },
+            singleInstanceOption);
+
+            var linkOptions = new DataflowLinkOptions()
+            {
+                PropagateCompletion = true
+            };
+            getApisBlock.LinkTo(collectApisBlock, linkOptions);
+
+            foreach (var file in files)
+            {
+                await getApisBlock.SendAsync(file);
+            }
+
+            getApisBlock.Complete();
+
+            await Task.WhenAll(getApisBlock.Completion, collectApisBlock.Completion);
+
+            return result;
+        }
+
+        private static UsageInformation GetApisUsedByAssembly(FileInfo file)
+        {
+            // Skip NuGet's own assemblies
+            string filename = Path.GetFileNameWithoutExtension(file.Name);
+            if (NuGetAssembly.MatchesName(filename)
+                || filename.Equals("NuGet.Core", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (filename.StartsWith("NuGet.", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine("Suspicious assembly name: " + file);
+            }
+
+            using (var fileStream = file.OpenRead())
+            using (var peReader = new PEReader(fileStream))
+            {
+                MetadataReader metadata;
+                try
+                {
+                    metadata = peReader.GetMetadataReader();
+                }
+                catch (InvalidOperationException)
+                {
+                    // Not a .NET assembly
+                    return null;
+                }
+
+                if (!AssemblyAnalyser.HasReferenceToNuGetAssembly(metadata))
+                {
+                    return null;
+                }
+
+                UsageInformation usedNuGetApis = AssemblyAnalyser.FindUsedNuGetApis(metadata);
+
+                return usedNuGetApis;
+            }
+        }
+
+        private static void WriteApiList(UsageInformation apis, TextWriter output)
+        {
+            var options = new JsonSerializerOptions()
+            {
+                WriteIndented = true
+            };
+            var json = JsonSerializer.Serialize(apis, options);
+            output.WriteLine(json);
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage/KeyValuePairExtensions.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/KeyValuePairExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace nuget_sdk_usage
+{
+    internal static class KeyValuePairExtensions
+    {
+        // Only needed while project targets netfx. If we can target netcoreapp3.1, this would be built-in.
+        internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)
+        {
+            key = kvp.Key;
+            value = kvp.Value;
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage/Program.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Program.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
-using System.Text.Json;
+﻿using nuget_sdk_usage.Analysis.Scanning;
+using nuget_sdk_usage.Updater;
+using System;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 
 namespace nuget_sdk_usage
 {
@@ -15,156 +12,25 @@ namespace nuget_sdk_usage
     {
         private static async Task Main(string[] args)
         {
-            if (!TryGetSearchPath(args, out var path))
+            // https://github.com/dotnet/command-line-api/issues/817
+            if (args.Length == 0)
             {
+                Console.WriteLine("Pass either the 'scan' or 'update' commands.");
                 return;
             }
 
-            var files =
-                Directory.EnumerateFiles(path, "*.dll", SearchOption.AllDirectories)
-                .Concat(Directory.EnumerateFiles(path, "*.exe", SearchOption.AllDirectories));
-
-            var usedApis = await GetUsageInformation(files);
-            WriteApiList(usedApis);
-        }
-
-        static bool TryGetSearchPath(string[] args, [NotNullWhen(true)] out string? path)
-        {
-            path = null;
-
-            if (args.Length == 0)
+            var rootCommand = new RootCommand()
             {
-                path = Environment.CurrentDirectory;
-                return true;
-            }
-            else if (args.Length == 1)
-            {
-                path = args[0];
-                if (!Directory.Exists(path))
-                {
-                    Console.WriteLine("Directory \"" + path + "\" does not exist");
-                    return false;
-                }
-                return true;
-            }
-            else
-            {
-
-                Console.WriteLine("Only one path expected. Found " + args.Length);
-                return false;
-            }
-        }
-
-        private static async Task<UsageInformation> GetUsageInformation(IEnumerable<string> files)
-        {
-            var result = new UsageInformation();
-
-            var multipleInstancesOption = new ExecutionDataflowBlockOptions
-            {
-                MaxDegreeOfParallelism = Environment.ProcessorCount
-            };
-            var singleInstanceOption = new ExecutionDataflowBlockOptions
-            {
-                MaxDegreeOfParallelism = 1
+                Scanner.GetCommand(),
+                Update.GetCommand()
             };
 
-            var getApisBlock = new TransformBlock<string, UsageInformation?>(GetApisUsedByAssembly, multipleInstancesOption);
-            var collectApisBlock = new ActionBlock<UsageInformation?>(assemblyInfo =>
-            {
-                if (assemblyInfo != null)
-                {
-                    foreach (var targetFramework in assemblyInfo.TargetFrameworks)
-                    {
-                        result.TargetFrameworks.Add(targetFramework);
-                    }
+            var cm = new CommandLineBuilder(rootCommand)
+                .UseDefaults()
+                .Build();
 
-                    foreach (var version in assemblyInfo.Versions)
-                    {
-                        result.Versions.Add(version);
-                    }
-
-                    foreach (var apisByAssembly in assemblyInfo.MemberReferences)
-                    {
-                        if (!result.MemberReferences.TryGetValue(apisByAssembly.Key, out HashSet<string>? allApis))
-                        {
-                            allApis = new HashSet<string>();
-                            result.MemberReferences[apisByAssembly.Key] = allApis;
-                        }
-
-                        foreach (var api in apisByAssembly.Value)
-                        {
-                            allApis.Add(api);
-                        }
-                    }
-                }
-            },
-            singleInstanceOption);
-
-            var linkOptions = new DataflowLinkOptions()
-            {
-                PropagateCompletion = true
-            };
-            getApisBlock.LinkTo(collectApisBlock, linkOptions);
-
-            foreach (var file in files)
-            {
-                await getApisBlock.SendAsync(file);
-            }
-
-            getApisBlock.Complete();
-
-            await Task.WhenAll(getApisBlock.Completion, collectApisBlock.Completion);
-
-            return result;
+            await cm.InvokeAsync(args);
         }
 
-        private static UsageInformation? GetApisUsedByAssembly(string file)
-        {
-            // Skip NuGet's own assemblies
-            string filename = Path.GetFileNameWithoutExtension(file);
-            if (NuGetAssembly.MatchesName(filename)
-                || filename.Equals("NuGet.Core", StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-
-            if (filename.StartsWith("NuGet.", StringComparison.OrdinalIgnoreCase))
-            {
-                Console.Error.WriteLine("Suspicious assembly name: " + file);
-            }
-
-            using var fileStream = File.OpenRead(file);
-            using var peReader= new PEReader(fileStream);
-
-            MetadataReader metadata;
-            try
-            {
-                metadata = peReader.GetMetadataReader();
-            }
-            catch (InvalidOperationException)
-            {
-                // Not a .NET assembly
-                return null;
-            }
-
-            if (!AssemblyAnalyser.HasReferenceToNuGetAssembly(metadata))
-            {
-                return null;
-            }
-
-            UsageInformation usedNuGetApis = AssemblyAnalyser.FindUsedNuGetApis(metadata);
-
-            return usedNuGetApis;
-        }
-
-        private static void WriteApiList(UsageInformation apis)
-        {
-            var options = new JsonSerializerOptions()
-            {
-                WriteIndented = true
-            };
-            var json = JsonSerializer.Serialize(apis, options);
-            Console.WriteLine(json);
-        }
     }
 }

--- a/nuget-sdk-usage/nuget-sdk-usage/Properties/AssemblyInfo.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("nuget-sdk-usage.Tests")]

--- a/nuget-sdk-usage/nuget-sdk-usage/Updater/AttributeUsageFinder.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Updater/AttributeUsageFinder.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+
+namespace nuget_sdk_usage.Updater
+{
+    internal class AttributeUsageFinder : CSharpSyntaxRewriter
+    {
+        private SemanticModel _semanticModel;
+        private List<string> _foundMembers;
+
+        internal AttributeUsageFinder(SemanticModel semanticModel)
+        {
+            _semanticModel = semanticModel;
+            _foundMembers = new List<string>();
+        }
+
+        internal IReadOnlyList<string> FoundMembers => _foundMembers;
+
+        public override SyntaxNode VisitAttribute(AttributeSyntax node)
+        {
+            var attributeType = _semanticModel.GetTypeInfo(node);
+            if (attributeType.Type == null)
+            {
+                throw new NotSupportedException("How could an attribute not have a type?");
+            }
+
+            var displayString = attributeType.Type.ToString();
+
+            if (displayString != UsedNuGetSdkApiAttribute.FullName)
+            {
+                return base.VisitAttribute(node);
+            }
+
+            var attributeList = node.Parent ?? throw new NotSupportedException("How can an attribute not have a parent?");
+            var member = attributeList.Parent ?? throw new NotSupportedException("How can an attribute list not have a parent?");
+            switch (member)
+            {
+                case FieldDeclarationSyntax fieldDeclarationSyntax:
+                    {
+                        foreach (var field in fieldDeclarationSyntax.Declaration.Variables)
+                        {
+                            var declaredSymbol = _semanticModel.GetDeclaredSymbol(field) ?? throw new NotSupportedException("How can a variable not have a declared symbol?");
+                            var name = declaredSymbol.ToDisplayString();
+                            _foundMembers.Add(name);
+                        }
+                    }
+                    return base.VisitAttribute(node);
+
+                case MethodDeclarationSyntax methodDeclarationSyntax:
+                    {
+                        var symbol = _semanticModel.GetDeclaredSymbol(methodDeclarationSyntax) ?? throw new NotSupportedException("How could a declared method not have a declared symbol?");
+                        var name = symbol.ToDisplayString();
+                        _foundMembers.Add(name);
+                    }
+                    return base.VisitAttribute(node);
+
+                case ClassDeclarationSyntax classDeclarationSyntax:
+                    {
+                        var symbol = _semanticModel.GetDeclaredSymbol(classDeclarationSyntax) ?? throw new NotSupportedException("How could a declared class not have a declared symbol?");
+                        var name = symbol.ToDisplayString();
+                        _foundMembers.Add(name);
+                    }
+                    return base.VisitAttribute(node);
+
+                case ConstructorDeclarationSyntax constructorDeclarationSyntax:
+                    {
+                        var symbol = _semanticModel.GetDeclaredSymbol(constructorDeclarationSyntax) ?? throw new NotSupportedException("How could a declared class not have a declared symbol?");
+                        var name = symbol.ToDisplayString();
+                        _foundMembers.Add(name);
+                    }
+                    return base.VisitAttribute(node);
+
+                case PropertyDeclarationSyntax propertyDeclarationSyntax:
+                    {
+                        var symbol = _semanticModel.GetDeclaredSymbol(propertyDeclarationSyntax) ?? throw new NotSupportedException("How could a declared property not have a declared symbol?");
+                        var name = symbol.ToDisplayString();
+                        _foundMembers.Add(name);
+                    }
+                    return base.VisitAttribute(node);
+
+                default:
+                    throw new NotSupportedException(member.GetType().Name);
+            }
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage/Updater/SourceUpdater.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Updater/SourceUpdater.cs
@@ -1,0 +1,175 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace nuget_sdk_usage.Updater
+{
+    internal class SourceUpdater : CSharpSyntaxRewriter
+    {
+        private Dictionary<string, UpdateAction> _actions;
+        private SemanticModel _semanticModel;
+
+        private static readonly AttributeListSyntax attributeListToAdd =
+            SyntaxFactory.AttributeList(
+                SyntaxFactory.SingletonSeparatedList<AttributeSyntax>(
+                    SyntaxFactory.Attribute(
+                        SyntaxFactory.QualifiedName(
+                            SyntaxFactory.QualifiedName(
+                                SyntaxFactory.IdentifierName("NuGet"),
+                                SyntaxFactory.IdentifierName("Shared")),
+                            SyntaxFactory.IdentifierName("UsedNuGetSdkApi")))))
+            .WithTrailingTrivia(SyntaxFactory.Whitespace("\r\n"));
+
+        public SourceUpdater(Dictionary<string, UpdateAction> actions, SemanticModel semanticModel)
+        {
+            _actions = actions;
+            _semanticModel = semanticModel;
+        }
+
+        public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            var declaredSymbol = _semanticModel.GetDeclaredSymbol(node) ?? throw new NotSupportedException("How could a constructor declaration not have a symbol?");
+            var name = declaredSymbol.ToString();
+
+            if (!_actions.TryGetValue(name, out var updateAction))
+            {
+                return node;
+            }
+
+            var newNode = ApplyAction(node, declaredSymbol, updateAction);
+            return newNode;
+        }
+
+        public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            var newNode = node;
+
+            foreach (var variableDeclaration in node.Declaration.Variables)
+            {
+                var declaredSymbol = _semanticModel.GetDeclaredSymbol(variableDeclaration) ?? throw new NotSupportedException("How could a field declaration not have a symbol?");
+                var name = declaredSymbol.ToString();
+
+                if (!_actions.TryGetValue(name, out var updateAction))
+                {
+                    continue;
+                }
+
+                newNode = ApplyAction(node, declaredSymbol, updateAction);
+            }
+
+            return newNode;
+        }
+
+        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            var declaredSymbol = _semanticModel.GetDeclaredSymbol(node) ?? throw new NotSupportedException("How could a method declaration not have a symbol?");
+            var name = declaredSymbol.ToString();
+
+            if (!_actions.TryGetValue(name, out var updateAction))
+            {
+                return node;
+            }
+
+            var newNode = ApplyAction(node, declaredSymbol, updateAction);
+            return newNode;
+        }
+
+        public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            var declaredSymbol = _semanticModel.GetDeclaredSymbol(node) ?? throw new NotSupportedException("How could a property declaration not have a symbol?");
+            var name = declaredSymbol.ToString();
+
+            if (!_actions.TryGetValue(name, out var action))
+            {
+                return node;
+            }
+
+            var newNode = ApplyAction(node, declaredSymbol, action);
+            return newNode;
+        }
+
+        private T ApplyAction<T>(T node, ISymbol symbol, UpdateAction updateAction)
+            where T : MemberDeclarationSyntax
+        {
+            var attributes = symbol.GetAttributes();
+            var attribute = attributes.SingleOrDefault(a => a.AttributeClass.ToString() == UsedNuGetSdkApiAttribute.FullName);
+
+            T newNode = null;
+            if (updateAction.AddAttribute && attribute == null)
+            {
+                if (node.AttributeLists.Count > 0)
+                {
+                    var leadingTrivia = node.GetLeadingTrivia();
+                    var whitespace = leadingTrivia.Last(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+                    newNode = (T)node.AddAttributeLists(attributeListToAdd.WithLeadingTrivia(whitespace));
+                }
+                else
+                {
+                    var leadingTrivia = node.GetLeadingTrivia();
+                    if (leadingTrivia.Count == 1 && leadingTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia))
+                    {
+                        newNode =
+                            (T)node.AddAttributeLists(attributeListToAdd.WithLeadingTrivia(leadingTrivia[0]));
+                    }
+                    else
+                    {
+                        var whitespaceTrivia = leadingTrivia.First(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+                        newNode =
+                            (T)node
+                            .WithLeadingTrivia(whitespaceTrivia)
+                            .AddAttributeLists(attributeListToAdd.WithLeadingTrivia(leadingTrivia));
+                    }
+                }
+            }
+            else if (!updateAction.AddAttribute && attribute != null)
+            {
+                var newAttributeLists = node.AttributeLists
+                    .Select(al =>
+                    {
+                        AttributeSyntax toRemove = null;
+
+                        foreach (var attr in al.Attributes)
+                        {
+                            var type = _semanticModel.GetTypeInfo(attr);
+                            if (type.Type == null) throw new NotSupportedException("AttributeSyntax's TypeInfo doesn't have a type");
+                            if (type.Type.ToString() == UsedNuGetSdkApiAttribute.FullName)
+                            {
+                                toRemove = attr;
+                                break;
+                            }
+                        }
+
+                        if (toRemove == null)
+                        {
+                            return al;
+                        }
+
+                        return SyntaxFactory.AttributeList(SyntaxFactory.SeparatedList(al.Attributes.Where(a => a != toRemove)));
+                    })
+                    .Where(al => al != null && al.Attributes.Count > 0);
+
+                var leadingTrivia = node.GetLeadingTrivia();
+                newNode = (T)node.WithAttributeLists(SyntaxFactory.List(newAttributeLists))
+                    .WithLeadingTrivia(leadingTrivia);
+            }
+
+            if (newNode != null)
+            {
+                if (updateAction.Actioned)
+                {
+                    // already actioned?
+                }
+                updateAction.SetActioned();
+
+                return newNode;
+            }
+            else
+            {
+                return node;
+            }
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage/Updater/Update.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Updater/Update.cs
@@ -1,0 +1,310 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using nuget_sdk_usage.Analysis.Assembly;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace nuget_sdk_usage.Updater
+{
+    internal class Update
+    {
+        internal static Command GetCommand()
+        {
+            var command = new Command("update")
+            {
+                new Option<DirectoryInfo>("--results")
+                {
+                    Argument = new Argument<DirectoryInfo>().ExistingOnly(),
+                    Required = true
+                },
+                new Option<DirectoryInfo>("--source")
+                {
+                    Argument = new Argument<DirectoryInfo>().ExistingOnly(),
+                    Required = true
+                }
+            };
+
+            command.Handler = CommandHandler.Create((Func<DirectoryInfo, DirectoryInfo, IConsole, Task<int>>)InvokeAsync);
+
+            return command;
+        }
+
+        private static async Task<int> InvokeAsync(DirectoryInfo results, DirectoryInfo source, IConsole console)
+        {
+            bool error = false;
+
+            if (!results.Exists)
+            {
+                error = true;
+                console.Error.WriteLine($"Directory \"{results.FullName}\" does not exist.");
+            }
+
+            var solutionFullFileName = new FileInfo(Path.Combine(source.FullName, "NuGet.sln"));
+            if (!solutionFullFileName.Exists)
+            {
+                error = true;
+                console.Error.WriteLine($"\"{solutionFullFileName}\" does not exist.");
+            }
+
+            if (error)
+            {
+                return -1;
+            }
+
+            Task<Dictionary<string, HashSet<string>>> getUsageTask = GetScanResults(results);
+            Task<(MSBuildWorkspace, Solution)> openSolutionTask = OpenSolutionAsync(solutionFullFileName);
+            Task<Dictionary<string, HashSet<string>>> getMembersWithAttributeTask = GetMembersWithAttributeAsync(openSolutionTask);
+            Task<Dictionary<string, Dictionary<string, bool>>> getDiffTask = GetDiffAsync(getUsageTask, getMembersWithAttributeTask);
+            Task updateSourceTask = UpdateSourceAsync(getDiffTask, openSolutionTask);
+
+            await Task.WhenAll(getUsageTask, openSolutionTask, getMembersWithAttributeTask, getDiffTask, updateSourceTask);
+
+            return 0;
+        }
+
+        private static async Task UpdateSourceAsync(Task<Dictionary<string, Dictionary<string, bool>>> getDiffTask, Task<(MSBuildWorkspace, Solution)> solutionTask)
+        {
+            var diffResults = await getDiffTask;
+            var (_, sln) = await solutionTask;
+
+            Console.WriteLine("Starting " + nameof(UpdateSourceAsync));
+
+            var actionsByAssembly = new Dictionary<string, Dictionary<string, UpdateAction>>();
+            foreach (var (assembly, diffActions) in diffResults)
+            {
+                var actions = new Dictionary<string, UpdateAction>();
+                foreach (var (member, add) in diffActions)
+                {
+                    actions.Add(member, new UpdateAction(add));
+                }
+
+                actionsByAssembly.Add(assembly, actions);
+            }
+
+            foreach (var project in sln.Projects)
+            {
+                var assembly = project.AssemblyName;
+                if (!actionsByAssembly.TryGetValue(assembly, out var actions))
+                {
+                    continue;
+                }
+
+                foreach (var document in project.Documents)
+                {
+                    var semanticModel = await document.GetSemanticModelAsync() ?? throw new NotSupportedException("Don't know how to handle case when semantic model unavailable.");
+                    var attributeUpdater = new SourceUpdater(actions, semanticModel);
+                    var before = await document.GetSyntaxRootAsync() ?? throw new NotSupportedException("Don't know how to handle case when document has no syntax root");
+                    var syntaxRoot = await document.GetSyntaxRootAsync();
+                    var after = attributeUpdater.Visit(syntaxRoot);
+                    if (!before.Equals(after))
+                    {
+                        var filename = document.FilePath ?? throw new NotSupportedException("A document without a file?");
+                        using (var fileStream = new StreamWriter(filename, append: false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+                        {
+                            after.WriteTo(fileStream);
+                        }
+                    }
+                }
+            }
+
+            int total = 0, updated = 0;
+            foreach (var (assembly, actions) in actionsByAssembly)
+            {
+                foreach (var (method, updateInfo) in actions)
+                {
+                    total++;
+                    if (!updateInfo.Actioned)
+                    {
+                        Console.Error.WriteLine("{0} was not actioned!", method);
+                    }
+                    else
+                    {
+                        updated++;
+                        // yay!
+                    }
+                }
+            }
+            Console.WriteLine("{0}/{1} updates applied.", updated, total);
+
+            Console.WriteLine("Finishing " + nameof(UpdateSourceAsync));
+        }
+
+        private static async Task<Dictionary<string, Dictionary<string, bool>>> GetDiffAsync(Task<Dictionary<string, HashSet<string>>> usedTask, Task<Dictionary<string, HashSet<string>>> attributedTask)
+        {
+            var used = await usedTask;
+            var attributed = await attributedTask;
+
+            Console.WriteLine("Starting " + nameof(GetDiffAsync));
+            var result = new Dictionary<string, Dictionary<string, bool>>();
+
+            HashSet<string> newAssemblies = new HashSet<string>();
+            HashSet<string> noLongerUsedAssemblies = attributed.Keys.ToHashSet();
+
+            foreach (var (usedAssembly, usedMembers) in used)
+            {
+                if (attributed.TryGetValue(usedAssembly, out var attributedMembers))
+                {
+                    noLongerUsedAssemblies.Remove(usedAssembly);
+
+                    var newMembers = new List<string>();
+                    var noLongerUsedMembers = attributedMembers.ToHashSet();
+
+                    foreach (var member in usedMembers)
+                    {
+                        if (noLongerUsedMembers.Contains(member))
+                        {
+                            noLongerUsedMembers.Remove(member);
+                        }
+                        else
+                        {
+                            newMembers.Add(member);
+                        }
+                    }
+
+                    if (newMembers.Count > 0 || noLongerUsedMembers.Count > 0)
+                    {
+                        var actions = new Dictionary<string, bool>();
+
+                        foreach (var member in newMembers)
+                        {
+                            actions.Add(member, true);
+                        }
+
+                        foreach (var member in noLongerUsedMembers)
+                        {
+                            actions.Add(member, false);
+                        }
+
+                        result.Add(usedAssembly, actions);
+                    }
+                }
+                else
+                {
+                    newAssemblies.Add(usedAssembly);
+                }
+            }
+
+            foreach (var assembly in newAssemblies)
+            {
+                var actions = new Dictionary<string, bool>();
+                foreach (var member in used[assembly])
+                {
+                    actions.Add(member, true);
+                }
+
+                result.Add(assembly, actions);
+            }
+
+            foreach (var assembly in noLongerUsedAssemblies)
+            {
+                var actions = new Dictionary<string, bool>();
+                foreach (var member in attributed[assembly])
+                {
+                    actions.Add(member, false);
+                }
+
+                result.Add(assembly, actions);
+            }
+
+            Console.WriteLine("Finishing " + nameof(GetDiffAsync));
+            return result;
+        }
+
+        private static async Task<Dictionary<string, HashSet<string>>> GetMembersWithAttributeAsync(Task<(MSBuildWorkspace, Solution)> arg1)
+        {
+            var (_, sln) = await arg1;
+
+            Console.WriteLine("Starting " + nameof(GetMembersWithAttributeAsync));
+            var result = new Dictionary<string, HashSet<string>>();
+
+            foreach (var project in sln.Projects)
+            {
+                var assembly = project.AssemblyName;
+
+                foreach (var document in project.Documents)
+                {
+                    var semanticModel = await document.GetSemanticModelAsync() ?? throw new NotSupportedException("Don't know how to handle case when semantic model unavailable.");
+                    var finder = new AttributeUsageFinder(semanticModel);
+
+                    finder.Visit(await document.GetSyntaxRootAsync());
+
+                    if (finder.FoundMembers.Count > 0)
+                    {
+                        if (!result.TryGetValue(assembly, out var members))
+                        {
+                            members = new HashSet<string>();
+                            result.Add(assembly, members);
+                        }
+
+                        foreach (var member in finder.FoundMembers)
+                        {
+                            members.Add(member);
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine("Finishing " + nameof(GetMembersWithAttributeAsync));
+            return result;
+        }
+
+        private static async Task<Dictionary<string, HashSet<string>>> GetScanResults(DirectoryInfo resultsDirectory)
+        {
+            Console.WriteLine("Starting " + nameof(GetScanResults));
+            var result = new Dictionary<string, HashSet<string>>();
+
+            var resultFiles = resultsDirectory.EnumerateFiles();
+            foreach (var file in resultFiles)
+            {
+                using (var stream = file.OpenRead())
+                {
+                    var usage = await JsonSerializer.DeserializeAsync<UsageInformation>(stream);
+
+                    foreach (var assemblyKvp in usage.MemberReferences)
+                    {
+                        if (!result.TryGetValue(assemblyKvp.Key, out var allMembers))
+                        {
+                            allMembers = new HashSet<string>();
+                            result.Add(assemblyKvp.Key, allMembers);
+                        }
+
+                        foreach (var member in assemblyKvp.Value)
+                        {
+                            allMembers.Add(member);
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine("Finishing " + nameof(GetScanResults));
+            return result;
+        }
+
+        private static async Task<(MSBuildWorkspace workspace, Solution solution)> OpenSolutionAsync(FileInfo solutionFullFileName)
+        {
+            Console.WriteLine("Starting " + nameof(OpenSolutionAsync));
+            Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults();
+
+            var workspace = MSBuildWorkspace.Create();
+            workspace.WorkspaceFailed += Workspace_WorkspaceFailed;
+
+            var sln = await workspace.OpenSolutionAsync(solutionFullFileName.FullName);
+
+            Console.WriteLine("Finishing " + nameof(OpenSolutionAsync));
+            return (workspace, sln);
+        }
+
+        private static void Workspace_WorkspaceFailed(object sender, WorkspaceDiagnosticEventArgs e)
+        {
+            Console.WriteLine(e.Diagnostic.Kind + ": " + e.Diagnostic.Message);
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage/Updater/UpdateAction.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Updater/UpdateAction.cs
@@ -1,0 +1,20 @@
+﻿namespace nuget_sdk_usage.Updater
+{
+    internal class UpdateAction
+    {
+        public UpdateAction(bool addAttribute)
+        {
+            AddAttribute = addAttribute;
+            Actioned = false;
+        }
+
+        public bool AddAttribute { get; }
+
+        public bool Actioned { get; private set; }
+
+        public void SetActioned()
+        {
+            Actioned = true;
+        }
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage/Updater/UsedNuGetSdkApiAttribute.cs
+++ b/nuget-sdk-usage/nuget-sdk-usage/Updater/UsedNuGetSdkApiAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace nuget_sdk_usage.Updater
+{
+    internal static class UsedNuGetSdkApiAttribute
+    {
+        internal static string FullName => "NuGet.Shared.UsedNuGetSdkApiAttribute";
+    }
+}

--- a/nuget-sdk-usage/nuget-sdk-usage/nuget-sdk-usage.csproj
+++ b/nuget-sdk-usage/nuget-sdk-usage/nuget-sdk-usage.csproj
@@ -1,12 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net472</TargetFramework> <!-- I want to use netcoreapp3.1 and nullable, but there are problems with MSBuild evaluation: https://github.com/microsoft/MSBuildLocator/issues/86 -->
     <RootNamespace>nuget_sdk_usage</RootNamespace>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <nullable>enable</nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
+  </ItemGroup>
 
 </Project>

--- a/nuget-sdk-usage/readme.md
+++ b/nuget-sdk-usage/readme.md
@@ -1,120 +1,32 @@
 # nuget-sdk-usage
 
-This is a tool to scan compiled binaries and build a list of all NuGet SDK APIs used. If run on numerous applications
-that use the NuGet SDK, it can help the NuGet client team understand which APIs are really used, and which are just
-internal, even if the C# accessibility modifier is public.
-
-Additionally, it checks which Target Framework Monikers (TFMs) assemblies that reference the NuGet SDK are using, as
-well as which versions of the NuGet SDK assemblies they were compiled against.
+This is a tool to help the NuGet client team better understand what NuGet SDK APIs are actually used, and which APIs have
+lower risk of causing problems if breaking changes are implemented.
 
 ## Usage
 
-The application takes one parameter, the directory where to scan for assemblies. If not provided, it searches from the current directory.
-The output is JSON, on standard output, which can be redirected to a file.
+The application has two modes, `scan` and `update`.
+
+### Scan
+
+To scan a directory for compiled assemblies, and analyse those assemblies for references to NuGet SDK assemblies, use the `scan` command.
+
+The command takes one argument, the directory to scan. It recursively searches all subdirectories for `*.dll` and `*.exe`, then analyses them to determine if they're .NET assemblies, and if so, if they reference NuGet SDK assemblies.
+
+There is an optional argument `--output`, which can be used to specify the filename of where the results should be written. If this argument is omitted, the scan results will be output to the console. Note that Windows shells often write text files with a Byte Order Marker (BOM), but this tool uses `System.Text.Json`, which does not support BOM, so it is generally does not work on Windows to redirect `scan` results to a file.
 
 ```ps1
-nuget-sdk-usage "c:\path\to\scan\" > results.json
+nuget-sdk-usage "c:\path\to\scan\\" --output results.json
 ```
 
-## Sample output
+### Update
 
-```json
-{
-  "TargetFrameworks": [
-    ".NET Framework 4.6.1",
-    ".NET Framework 4.5.1",
-    ".NET Framework 4.7.2"
-  ],
-  "Versions": [
-    "4.8.0.6",
-    "5.0.0.6",
-    "5.0.0.2",
-    "4.8.0.5"
-  ],
-  "MemberReferences": {
-    "NuGet.Versioning": [
-      "NuGet.Versioning.SemanticVersion.op_Equality(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
-      "NuGet.Versioning.VersionRangeBase.Satisfies(NuGet.Versioning.NuGetVersion)",
-      "NuGet.Versioning.VersionRangeBase.get_HasLowerBound()",
-      "NuGet.Versioning.VersionRangeBase.get_IsMinInclusive()",
-      "NuGet.Versioning.VersionRangeBase.get_MinVersion()",
-      "NuGet.Versioning.SemanticVersion.op_LessThan(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
-      "NuGet.Versioning.SemanticVersion.op_LessThanOrEqual(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
-      "NuGet.Versioning.VersionRangeBase.get_HasUpperBound()",
-      "NuGet.Versioning.VersionRangeBase.get_IsMaxInclusive()",
-      "NuGet.Versioning.VersionRangeBase.get_MaxVersion()",
-      "NuGet.Versioning.SemanticVersion.op_GreaterThan(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
-      "NuGet.Versioning.SemanticVersion.op_GreaterThanOrEqual(NuGet.Versioning.SemanticVersion, NuGet.Versioning.SemanticVersion)",
-      "NuGet.Versioning.NuGetVersion.TryParse(System.String, NuGet.Versioning.NuGetVersion)",
-      "NuGet.Versioning.VersionRange.Parse(System.String)",
-      "NuGet.Versioning.SemanticVersion.ToFullString()",
-      "NuGet.Versioning.VersionRange.CommonSubSet(System.Collections.Generic.IEnumerable\u00601\u003CNuGet.Versioning.VersionRange\u003E)",
-      "NuGet.Versioning.VersionRange.TryParse(System.String, NuGet.Versioning.VersionRange)",
-      "NuGet.Versioning.SemanticVersion.ToNormalizedString()",
-      "NuGet.Versioning.NuGetVersion.Parse(System.String)"
-    ],
-    "NuGet.Frameworks": [
-      "NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net35",
-      "NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net4",
-      "NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net45",
-      "NuGet.Frameworks.FrameworkConstants.CommonFrameworks.NetCoreApp10",
-      "NuGet.Frameworks.FrameworkConstants.CommonFrameworks.UAP10",
-      "NuGet.Frameworks.NuGetFramework.Parse(System.String)",
-      "NuGet.Frameworks.NuGetFramework.get_IsUnsupported()",
-      "NuGet.Frameworks.NuGetFramework.get_DotNetFrameworkName()",
-      "NuGet.Frameworks.NuGetFramework.get_Version()",
-      "NuGet.Frameworks.NuGetFramework.GetShortFolderName()"
-    ],
-    "NuGet.ProjectModel": [
-      "NuGet.ProjectModel.LockFileUtilities.GetLockFile(System.String, NuGet.Common.ILogger)",
-      "NuGet.ProjectModel.LockFile.get_Targets()",
-      "NuGet.ProjectModel.LockFileTarget.get_Libraries()",
-      "NuGet.ProjectModel.LockFileTargetLibrary.get_Type()",
-      "NuGet.ProjectModel.LockFileTargetLibrary.get_CompileTimeAssemblies()",
-      "NuGet.ProjectModel.LockFileItem.get_Path()",
-      "NuGet.ProjectModel.LockFileTargetLibrary.get_Name()",
-      "NuGet.ProjectModel.LockFileTargetLibrary.get_Version()"
-    ],
-    "NuGet.Protocol": [
-      "NuGet.Protocol.Plugins.IRequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod, NuGet.Protocol.Plugins.IRequestHandler)",
-      "NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection, NuGet.Protocol.Plugins.Message, System.TimeSpan, System.Threading.CancellationToken)",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.get_IsRetry()",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.get_Uri()",
-      "NuGet.Protocol.Plugins.GetOperationClaimsRequest.get_PackageSourceRepository()",
-      "NuGet.Protocol.Plugins.GetOperationClaimsRequest.get_ServiceIndex()",
-      "NuGet.Protocol.Plugins.GetOperationClaimsResponse..ctor(System.Collections.Generic.IEnumerable\u00601\u003CNuGet.Protocol.Plugins.OperationClaim\u003E)",
-      "NuGet.Protocol.Plugins.InitializeResponse..ctor(NuGet.Protocol.Plugins.MessageResponseCode)",
-      "NuGet.Protocol.Plugins.Message.get_Method()",
-      "NuGet.Protocol.Plugins.Message.get_RequestId()",
-      "NuGet.Protocol.Plugins.SetCredentialsResponse..ctor(NuGet.Protocol.Plugins.MessageResponseCode)",
-      "NuGet.Protocol.Plugins.SetLogLevelRequest.get_LogLevel()",
-      "NuGet.Protocol.Plugins.SetLogLevelResponse..ctor(NuGet.Protocol.Plugins.MessageResponseCode)",
-      "NuGet.Protocol.Plugins.LogRequest..ctor(NuGet.Common.LogLevel, System.String)",
-      "NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync(NuGet.Protocol.Plugins.MessageMethod, T0, System.Threading.CancellationToken)",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse..ctor(System.String, System.String, System.String, System.Collections.Generic.IList\u00601\u003CSystem.String\u003E, NuGet.Protocol.Plugins.MessageResponseCode)",
-      "NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader)",
-      "NuGet.Protocol.Plugins.PluginFactory.CreateFromCurrentProcessAsync(NuGet.Protocol.Plugins.IRequestHandlers, NuGet.Protocol.Plugins.ConnectionOptions, System.Threading.CancellationToken)",
-      "NuGet.Protocol.Plugins.IPlugin.get_Connection()",
-      "NuGet.Protocol.Plugins.IRequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod, NuGet.Protocol.Plugins.IRequestHandler)",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest..ctor(System.Uri, System.Boolean, System.Boolean, System.Boolean)",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.get_Username()",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.get_Password()",
-      "NuGet.Protocol.Plugins.ProtocolErrorEventArgs.get_Message()",
-      "NuGet.Protocol.Plugins.Message.get_Type()",
-      "NuGet.Protocol.Plugins.ProtocolErrorEventArgs.get_Exception()",
-      "NuGet.Protocol.Plugins.IConnection.add_Faulted(System.EventHandler\u00601\u003CNuGet.Protocol.Plugins.ProtocolErrorEventArgs\u003E)",
-      "NuGet.Protocol.Plugins.IPlugin.add_BeforeClose(System.EventHandler)",
-      "NuGet.Protocol.Plugins.IPlugin.add_Closed(System.EventHandler)",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.get_IsNonInteractive()",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.get_CanShowDialog()",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.get_ResponseCode()",
-      "NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.get_Message()",
-      "NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload(NuGet.Protocol.Plugins.Message)",
-      "NuGet.Protocol.Plugins.Message.get_Payload()",
-      "NuGet.Protocol.Plugins.MessageUtilities.Create(System.String, NuGet.Protocol.Plugins.MessageType, NuGet.Protocol.Plugins.MessageMethod)",
-      "NuGet.Protocol.Plugins.IConnection.SendAsync(NuGet.Protocol.Plugins.Message, System.Threading.CancellationToken)",
-      "NuGet.Protocol.Plugins.IResponseHandler.SendResponseAsync(NuGet.Protocol.Plugins.Message, T0, System.Threading.CancellationToken)"
-    ]
-  }
-}
+The `update` command will merge all `scan` results into a list of all APIs known to be used, then modify the `NuGet.Client` repo to mark those APIs with a `UsedNuGetSdkApi` attribute. It has two arguments.
+
+`--results` is used to specify the directory where `scan` results are. It will load all `*.json` files.
+
+`--source` specifies the location of the `NuGet.Client` repo.
+
+```ps1
+nuget-sdk-usage --results "c:\path\to\results\\" --source "c:\path\to\NuGet.Client\\"
 ```


### PR DESCRIPTION
Using it to scan Visual Studio and Rider binaries, there are some used APIs that this tool is unable to find/modify in the `NuGet.Client` source, but it's finding most of them. Will continue to make more improvements over more PRs.