### PR TITLE
Improve changelogger problems found during 5.6 note creation

### DIFF
--- a/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
+++ b/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
@@ -23,7 +23,4 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="zenhub.net" Version="1.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
 </Project>

--- a/ChangelogGenerator/ChangelogGenerator/IssueLabels.cs
+++ b/ChangelogGenerator/ChangelogGenerator/IssueLabels.cs
@@ -8,7 +8,7 @@ namespace ChangelogGenerator
 {
     class IssueLabels
     {
-        public static string ClosedPrefix = "ClosedAs:";
+        public static string ClosedPrefix = "Resolution:";
         public static string RegressionDuringThisVersion = "RegressionDuringThisVersion";
         public static string EngImprovement = "Category:Engineering";
         public static string Epic = "Epic";
@@ -16,6 +16,8 @@ namespace ChangelogGenerator
         public static string DCR = "Type:DCR";
         public static string Bug = "Type:Bug";
         public static string Spec = "Type:Spec";
+        public static string Test = "Type:Test";
+        public static string Docs = "Type:Docs";
 
     }
 }

--- a/ChangelogGenerator/ChangelogGenerator/IssueType.cs
+++ b/ChangelogGenerator/ChangelogGenerator/IssueType.cs
@@ -13,5 +13,6 @@ namespace ChangelogGenerator
         Bug,
         DCR,
         Spec,
+        StillOpen,
     }
 }

--- a/ChangelogGenerator/ChangelogGenerator/Options.cs
+++ b/ChangelogGenerator/ChangelogGenerator/Options.cs
@@ -24,8 +24,6 @@ namespace ChangelogGenerator
         [Option('v', "verbose", HelpText = "Print details during execution.")]
         public bool Verbose { get; set; }
 
-        [Option('o', "include-open", HelpText = "Include open issues.")]
-        public bool IncludeOpen { get; set; }
 
         [Usage(ApplicationAlias = "changelog-generator")]
         public static IEnumerable<Example> Examples

--- a/ChangelogGenerator/ChangelogGenerator/Program.cs
+++ b/ChangelogGenerator/ChangelogGenerator/Program.cs
@@ -18,7 +18,7 @@ namespace ChangelogGenerator
                     {
                         try
                         {
-                            var fileName = "Changelog-" + options.Release
+                            var fileName = "NuGet-" + options.Release
                                 + (string.IsNullOrEmpty(options.RequiredLabel) ? "" : options.RequiredLabel) + ".md";
 
                             File.WriteAllText(fileName, await new ChangelogGenerator(options).GenerateChangelog());

--- a/ChangelogGenerator/ChangelogGenerator/Readme.txt
+++ b/ChangelogGenerator/ChangelogGenerator/Readme.txt
@@ -1,1 +1,0 @@
-﻿ChangelogGenerator -o NuGet -r Home -m "4.9" -t <key here>


### PR DESCRIPTION
Fixed: https://github.com/NuGet/Client.Engineering/issues/322
- ignore issues which aren't from nuget/home
- Type: Test - should not be in release notes
- Type: Docs - should not be in release notes
- issues that were still open were included. - now they are include in a section called "StillOpens"
- improve the output to match what we publish
- change file name to match final name of file
- change header to: DCRs from DCR and to Bugs from Bug

Tested by diffing output of tool vs. our current PR for 5.6 release notes.