### PR TITLE
enable skipping validation of net45 assemblies

### DIFF
--- a/NuGetBuildValidators/NuGetValidator.Localization/LocalizationValidator.cs
+++ b/NuGetBuildValidators/NuGetValidator.Localization/LocalizationValidator.cs
@@ -125,7 +125,7 @@ namespace NuGetValidator.Localization
             return exitCode;
         }
 
-        public static int ExecuteForArtifacts(string ArtifactsPath, string OutputPath, string CommentsPath)
+        public static int ExecuteForArtifacts(string ArtifactsPath, string OutputPath, string CommentsPath, string filterPathsContaining)
         {
             var artifactsPath = ArtifactsPath;
             var logPath = OutputPath;
@@ -142,7 +142,7 @@ namespace NuGetValidator.Localization
 
             var englishDlls = FileUtility.GetDlls(artifactsPath,
                                                   isArtifacts: true,
-                                                  skipPathsContaining: "net45"); // net45 assemblies aren't localized, ignore them
+                                                  filterPathsContaining: filterPathsContaining);
 
             Execute(lciCommentsDirPath, englishDlls);
 

--- a/NuGetBuildValidators/NuGetValidator.Localization/LocalizationValidator.cs
+++ b/NuGetBuildValidators/NuGetValidator.Localization/LocalizationValidator.cs
@@ -140,7 +140,9 @@ namespace NuGetValidator.Localization
 
             WarnIfNoLciDirectory(lciCommentsDirPath);
 
-            var englishDlls = FileUtility.GetDlls(artifactsPath, isArtifacts: true);
+            var englishDlls = FileUtility.GetDlls(artifactsPath,
+                                                  isArtifacts: true,
+                                                  skipPathsContaining: "net45"); // net45 assemblies aren't localized, ignore them
 
             Execute(lciCommentsDirPath, englishDlls);
 

--- a/NuGetBuildValidators/NuGetValidator.Localization/NuGetValidator.Localization.csproj
+++ b/NuGetBuildValidators/NuGetValidator.Localization/NuGetValidator.Localization.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.1.0</Version>
+    <Version>2.0.3.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageVersion Condition=" '$(ReleaseLabel)'!=''">$(Version)-$(ReleaseLabel)</PackageVersion>

--- a/NuGetBuildValidators/NuGetValidator.Utility/FileUtility.cs
+++ b/NuGetBuildValidators/NuGetValidator.Utility/FileUtility.cs
@@ -7,7 +7,7 @@ namespace NuGetValidator.Utility
 {
     public class FileUtility
     {
-        public static string[] GetDlls(string root, bool isArtifacts = false)
+        public static string[] GetDlls(string root, bool isArtifacts = false, string skipPathsContaining = null)
         {
             if (isArtifacts)
             {
@@ -29,6 +29,7 @@ namespace NuGetValidator.Utility
                     var englishDlls = Directory.GetFiles(dir, expectedDllName, SearchOption.AllDirectories)
                         .Where(p => p.Contains("bin") || (Path.GetFileName(dir).StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase) && p.Contains("lib")))
                         .Where(p => !p.Contains("ilmerge"))
+                        .Where(p => skipPathsContaining == null || !p.Contains(skipPathsContaining))
                         .OrderBy(p => p);
 
                     if (englishDlls.Any())

--- a/NuGetBuildValidators/NuGetValidator.Utility/FileUtility.cs
+++ b/NuGetBuildValidators/NuGetValidator.Utility/FileUtility.cs
@@ -7,7 +7,7 @@ namespace NuGetValidator.Utility
 {
     public class FileUtility
     {
-        public static string[] GetDlls(string root, bool isArtifacts = false, string skipPathsContaining = null)
+        public static string[] GetDlls(string root, bool isArtifacts = false, string filterPathsContaining = null)
         {
             if (isArtifacts)
             {
@@ -29,7 +29,7 @@ namespace NuGetValidator.Utility
                     var englishDlls = Directory.GetFiles(dir, expectedDllName, SearchOption.AllDirectories)
                         .Where(p => p.Contains("bin") || (Path.GetFileName(dir).StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase) && p.Contains("lib")))
                         .Where(p => !p.Contains("ilmerge"))
-                        .Where(p => skipPathsContaining == null || !p.Contains(skipPathsContaining))
+                        .Where(p => filterPathsContaining == null || !p.Contains(filterPathsContaining))
                         .OrderBy(p => p);
 
                     if (englishDlls.Any())

--- a/NuGetBuildValidators/NuGetValidator.Utility/NuGetValidator.Utility.csproj
+++ b/NuGetBuildValidators/NuGetValidator.Utility/NuGetValidator.Utility.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.1.0</Version>
+    <Version>2.0.3.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageVersion Condition=" '$(ReleaseLabel)'!=''">$(Version)-$(ReleaseLabel)</PackageVersion>

--- a/NuGetBuildValidators/NuGetValidator/LocalizationValidatorCommand.cs
+++ b/NuGetBuildValidators/NuGetValidator/LocalizationValidatorCommand.cs
@@ -18,6 +18,7 @@ namespace NuGetValidator
         private static readonly string OutputPathDescription = "Path to the directory for writing errors. File need not be present, but Program should have write access to the location.";
         private static readonly string CommentsPathDescription = "Path to the local NuGet localization repository. e.g. - <repo_root>\\Main\\localize\\comments\\15";
         private static readonly string ArtifactsPathDescription = "Path to the local NuGet artifacts folder. This option is used to validate a locally built NuGet repository.";
+        private static readonly string FilterPathsContainingDescription = "Filter out any artifacts containing this value in its path.";
 
 
         public static void Register(CommandLineApplication app)
@@ -57,6 +58,11 @@ namespace NuGetValidator
                     ArtifactsPathDescription,
                     CommandOptionType.SingleValue);
 
+                var filterPathsContaining = localizationValidator.Option(
+                    "--filter-paths-containing",
+                    FilterPathsContainingDescription,
+                    CommandOptionType.SingleValue);
+
                 localizationValidator.OnExecute(() =>
                 {
                     var exitCode = 0;
@@ -87,7 +93,7 @@ namespace NuGetValidator
                         }
                         else
                         {
-                            exitCode = LocalizationValidator.ExecuteForArtifacts(artifactsPath.Value(), outputPath.Value(), commentsPath.Value());
+                            exitCode = LocalizationValidator.ExecuteForArtifacts(artifactsPath.Value(), outputPath.Value(), commentsPath.Value(), filterPathsContaining.Value());
                         }
                     }
 

--- a/NuGetBuildValidators/NuGetValidator/NuGetValidator.csproj
+++ b/NuGetBuildValidators/NuGetValidator/NuGetValidator.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.2.0</Version>
+    <Version>2.0.3.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageVersion Condition=" '$(ReleaseLabel)'!=''">$(Version)-$(ReleaseLabel)</PackageVersion>


### PR DESCRIPTION
microsoft loc tool having problems localizing both net45 and net472 assemblies of the same identity.
so i'm skipping loc of net45.
however, this loc validation tool then fails the build because net45 assemblies aren't localized.

Update: going to go ahead and enable workaround, but not hardcode it...instead enable command line param to filter net45 or not.  Timeframe is short to deliver packages to partner team.