### PR TITLE
Change TestCertGenerator\CreateTestCertificate.ps1 for manual cross verify tests

### DIFF
--- a/TestCertGenerator/CreateTestCertificate.ps1
+++ b/TestCertGenerator/CreateTestCertificate.ps1
@@ -10,7 +10,6 @@ Param(
     [switch] $AlternateSignatureAlgorithm,
     [string] $Type = "CodeSigningCert",
     [switch] $GenerateCerFile
-
 )
 
 $friendlyName = "5914c830-f5c7-4dae-aeed-86566bbf213a"


### PR DESCRIPTION
Add -GenerateCerFile option, so that we can export the .cer file and import on MacOS and Linux.

Add -KeyUsage CertSign, CRLSign, as without this change, the self-signed certificate will not be trusted on Linux
Related issue: https://github.com/NuGet/Home/issues/8841