### PR TITLE
Use local feed

### DIFF
--- a/ContentFilesExample/NuGet.Config
+++ b/ContentFilesExample/NuGet.Config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     <add key="local" value="authoring" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
`nuget.org` feed is not required because there no package dependencies in the example.

@loic-sharma for review.