### PR TITLE
Fix the script by passing version to avoid net6.0

### DIFF
--- a/SDKPatchTool/patchOnUnix.ps1
+++ b/SDKPatchTool/patchOnUnix.ps1
@@ -1,7 +1,11 @@
 # patchSDKFolder is the folder stores the patched SDK. It will be created if it doesn't exist.
 $patchSDKFolder = "/home/henli/patchSDK"
+
 # nupkgsPath is the nupkgs folder which contains the latest nupkgs.
 $nupkgsPath = "/home/henli/Nupkgs"
+
+# SDKVersion is the version of dotnet/sdk which NuGet is inserting into.
+$SDKVersion = "5.0.100"
 
 . "./patchUtil.ps1"
 
@@ -16,15 +20,15 @@ if (!(Test-Path $patchSDKFolder/dotnet-install.sh)) {
 }
 
 sudo chmod u+x $patchSDKFolder/dotnet-install.sh
-& $patchSDKFolder/dotnet-install.sh -i $patchSDKFolder -c master -v latest -NoPath
+& $patchSDKFolder/dotnet-install.sh -i $patchSDKFolder -c master -v $SDKVersion -NoPath
 
         
 $DOTNET = Join-Path -Path $patchSDKFolder -ChildPath 'dotnet'
 # Display current version
 & $DOTNET --version
-$SDKVersion = & $DOTNET --version
+$DownloadedSDKVersion = & $DOTNET --version
 
-$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $SDKVersion -nupkgsPath $nupkgsPath
+$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $DownloadedSDKVersion -nupkgsPath $nupkgsPath
 
 if ($result -eq $true)
 {

--- a/SDKPatchTool/patchOnWindows.ps1
+++ b/SDKPatchTool/patchOnWindows.ps1
@@ -1,7 +1,11 @@
 # patchSDKFolder is the folder stores the patched SDK. It will be created if it doesn't exist.
 $patchSDKFolder = "C:\PatchedSDK"
+
 # nupkgsPath is the nupkgs folder which contains the latest nupkgs.
 $nupkgsPath = "C:\repos\NuGet.Client\artifacts\nupkgs"
+
+# SDKVersion is the version of dotnet/sdk which NuGet is inserting into.
+$SDKVersion = "5.0.100"
 
 . ".\patchUtil.ps1"
 
@@ -14,15 +18,15 @@ if (!(Test-Path $patchSDKFolder\dotnet-install.ps1)) {
     Invoke-WebRequest https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1 -OutFile $patchSDKFolder\dotnet-install.ps1
 }
 
-& $patchSDKFolder\dotnet-install.ps1 -i $patchSDKFolder -c master -v latest -NoPath
+& $patchSDKFolder\dotnet-install.ps1 -i $patchSDKFolder -c master -v $SDKVersion -NoPath
 
         
 $DOTNET = Join-Path -Path $patchSDKFolder -ChildPath 'dotnet'
 # Display current version
 & $DOTNET --version
-$SDKVersion = & $DOTNET --version
+$DownloadedSDKVersion = & $DOTNET --version
 
-$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $SDKVersion -nupkgsPath $nupkgsPath
+$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $DownloadedSDKVersion -nupkgsPath $nupkgsPath
 
 if ($result -eq $true)
 {


### PR DESCRIPTION
This is a temporary fix.
The TFMs are hardcoded so it will change when it's net6.0.
We need to pass the TFMs in sequence or use get nearest function in PowerShell.