### PR TITLE
Adds LocProjectValidator tool 

### DIFF
--- a/LocProjectValidator/LocProject.cs
+++ b/LocProjectValidator/LocProject.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace LocProjectValidator
+{
+    public class LocProject
+    {
+        public DateTime DateTime { get; set; }
+        public string BuildSystem { get; set; }
+        public SourceControl SourceControl { get; set; }
+        public object[] LanguageSets { get; set; }
+        public Project[] Projects { get; set; }
+        public LanguageFolderMappings LanguageFolderMappings { get; set; }
+    }
+
+    public class SourceControl
+    {
+        public string Type { get; set; }
+        public string Url { get; set; }
+        public string Branch { get; set; }
+        public string Repository { get; set; }
+    }
+
+    public class LanguageFolderMappings
+    {
+        public string CHS { get; set; }
+        public string CHT { get; set; }
+        public string CSY { get; set; }
+        public string DEU { get; set; }
+        public string ESN { get; set; }
+        public string FRA { get; set; }
+        public string ITA { get; set; }
+        public string JPN { get; set; }
+        public string KOR { get; set; }
+        public string PLK { get; set; }
+        public string PTB { get; set; }
+        public string RUS { get; set; }
+        public string TRK { get; set; }
+    }
+
+    public class Project
+    {
+        public string Name { get; set; }
+        public string Path { get; set; }
+        public LocItem[] LocItems { get; set; }
+        public object[] LssFiles { get; set; }
+    }
+
+    public class LocItem
+    {
+        public string SourceFile { get; set; }
+        public string LclFile { get; set; }
+        public string LcgFile { get; set; }
+        public string LciFile { get; set; }
+        public string Languages { get; set; }
+        public string CopyOption { get; set; }
+        public string[] LssFiles { get; set; }
+    }
+}

--- a/LocProjectValidator/LocProjectValidator.csproj
+++ b/LocProjectValidator/LocProjectValidator.csproj
@@ -9,6 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>LocProjectValidator</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LocProjectValidator/LocProjectValidator.csproj
+++ b/LocProjectValidator/LocProjectValidator.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <Version>0.0.1</Version>
+    <Description>Verifies LocProject.json file entries againts files contained in a AzDO localization artifact</Description>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>LocProjectValidator</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+  </ItemGroup>
+
+</Project>

--- a/LocProjectValidator/LocProjectValidator.csproj
+++ b/LocProjectValidator/LocProjectValidator.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <Description>Verifies LocProject.json file entries againts files contained in a AzDO localization artifact</Description>
 
     <PackAsTool>true</PackAsTool>

--- a/LocProjectValidator/LocProjectValidator.sln
+++ b/LocProjectValidator/LocProjectValidator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31129.286
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LocProjectValidator", "LocProjectValidator.csproj", "{B0799C83-6D7A-4F97-BD80-95C01581006C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B0799C83-6D7A-4F97-BD80-95C01581006C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0799C83-6D7A-4F97-BD80-95C01581006C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0799C83-6D7A-4F97-BD80-95C01581006C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0799C83-6D7A-4F97-BD80-95C01581006C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5D06D161-968E-45B5-B706-80B0F1D96938}
+	EndGlobalSection
+EndGlobal

--- a/LocProjectValidator/Program.cs
+++ b/LocProjectValidator/Program.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Text.Json;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace LocProjectValidator
+{
+    public class Program
+    {
+        public static async Task<int> Main(string[] args)
+        {
+            var rootCommand = new RootCommand
+            {
+                new Argument<string>(
+                    "loc-project-file",
+                    description: "Input path to LocProject.json file"),
+                new Argument<string>(
+                    "artifacts-dir",
+                    description: "Localization Artifacts folder to validate LocProject.json file entries"),
+            };
+
+            rootCommand.Description = "Verifies LocProject.json file entries againts files contained in a AzDO localization artifact";
+
+            rootCommand.Handler = CommandHandler.Create<string, string>(Run);
+
+            return await rootCommand.InvokeAsync(args);
+        }
+
+        private static void Run(string locProjectFile, string artifactsDir)
+        {
+            var text = File.ReadAllText(locProjectFile);
+            var locProject = JsonSerializer.Deserialize<LocProject>(text);
+
+            foreach (var prj in locProject.Projects)
+            {
+                foreach (var locItem in prj.LocItems)
+                {
+                    ValidateFile(locItem.SourceFile, nameof(locItem.SourceFile), artifactsDir, locItem);
+                    ValidateFile(locItem.LcgFile, nameof(locItem.LcgFile), artifactsDir, locItem);
+                    ValidateFile(locItem.LclFile, nameof(locItem.LclFile), artifactsDir, locItem);
+                    ValidateFile(locItem.LciFile, nameof(locItem.LciFile), artifactsDir, locItem);
+                }
+            }
+        }
+
+        private static void ValidateFile(string locPath, string attributeName, string workingDir, LocItem rootObj)
+        {
+            if (string.IsNullOrEmpty(locPath))
+            {
+                Console.WriteLine("Warning: {0} is empty, source={1}", attributeName, rootObj.SourceFile);
+                return;
+            }
+            var fullPath = Path.IsPathRooted(locPath) ? locPath : Path.Combine(workingDir, locPath);
+
+            if (fullPath.Contains("{Lang}"))
+            {
+                foreach(var pi in typeof(LanguageFolderMappings).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    fullPath = fullPath.Replace("{Lang}", pi.Name);
+
+                    if (!File.Exists(fullPath))
+                    {
+                        Console.WriteLine("Warning: {0}={1} does not exists", attributeName, fullPath);
+                    }
+                }
+            }
+            else
+            {
+                if (!File.Exists(fullPath))
+                {
+                    Console.WriteLine("Warning: {0}={1} does not exists", attributeName, fullPath);
+                }
+            }
+        }
+    }
+}

--- a/LocProjectValidator/Program.cs
+++ b/LocProjectValidator/Program.cs
@@ -20,16 +20,19 @@ namespace LocProjectValidator
                 new Argument<string>(
                     "artifacts-dir",
                     description: "Localization Artifacts folder to validate LocProject.json file entries"),
+                new Argument<string>(
+                    "loc-repo-dir",
+                    description: "Localization repository folder to validate LocProject.json file entries"),
             };
 
             rootCommand.Description = "Verifies LocProject.json file entries againts files contained in a AzDO localization artifact";
 
-            rootCommand.Handler = CommandHandler.Create<string, string>(Run);
+            rootCommand.Handler = CommandHandler.Create<string, string, string>(Run);
 
             return await rootCommand.InvokeAsync(args);
         }
 
-        private static void Run(string locProjectFile, string artifactsDir)
+        private static void Run(string locProjectFile, string artifactsDir, string locRepoDir)
         {
             var text = File.ReadAllText(locProjectFile);
             var locProject = JsonSerializer.Deserialize<LocProject>(text);
@@ -40,8 +43,8 @@ namespace LocProjectValidator
                 {
                     ValidateFile(locItem.SourceFile, nameof(locItem.SourceFile), artifactsDir, locItem);
                     ValidateFile(locItem.LcgFile, nameof(locItem.LcgFile), artifactsDir, locItem);
-                    ValidateFile(locItem.LclFile, nameof(locItem.LclFile), artifactsDir, locItem);
-                    ValidateFile(locItem.LciFile, nameof(locItem.LciFile), artifactsDir, locItem);
+                    ValidateFile(locItem.LclFile, nameof(locItem.LclFile), locRepoDir, locItem);
+                    ValidateFile(locItem.LciFile, nameof(locItem.LciFile), locRepoDir, locItem);
                 }
             }
         }


### PR DESCRIPTION
This tool is useful for verifying localization artifacts generated at CI pipeline.

LocProjectValidator requires two inputs:

- LocProject.json file: A json file containing file entries to be localized + some localization metadata files (.lci, .lcl). [Example in dotnet/arcade](https://github.com/dotnet/arcade/blob/69b0cf80bc08bf30c4a6beed4f8c7d41a353e948/eng/common/generate-locproject.ps1).
- Artifacts folder: a local, downloaded, uncompressed localization artifacts

The tool prints warnings regarding files described in LocProject.json not found in the Artifacts folder.