### PR TITLE
Fix the patching script

### DIFF
--- a/SDKPatchTool/patchOnUnix.ps1
+++ b/SDKPatchTool/patchOnUnix.ps1
@@ -10,7 +10,7 @@ $SDKVersion = "latest"
 # Channel name of SDK. Pls refer to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options
 # "Current" - Most current release (For now, it's 5.x)
 # "main" - Branch name of a preview channel (For now, it's 6.x)
-$SDKChannel = "Current"
+$SDKChannel = "main"
 
 . "./patchUtil.ps1"
 

--- a/SDKPatchTool/patchOnUnix.ps1
+++ b/SDKPatchTool/patchOnUnix.ps1
@@ -1,11 +1,16 @@
 # patchSDKFolder is the folder stores the patched SDK. It will be created if it doesn't exist.
-$patchSDKFolder = "/home/henli/patchSDK"
+$patchSDKFolder = "/Users/heng/patchSDK"
 
 # nupkgsPath is the nupkgs folder which contains the latest nupkgs.
-$nupkgsPath = "/home/henli/Nupkgs"
+$nupkgsPath = "/Users/heng/Nupkgs"
 
 # SDKVersion is the version of dotnet/sdk which NuGet is inserting into.
-$SDKVersion = "5.0.100"
+$SDKVersion = "latest"
+
+# Channel name of SDK. Pls refer to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options
+# "Current" - Most current release (For now, it's 5.x)
+# "main" - Branch name of a preview channel (For now, it's 6.x)
+$SDKChannel = "Current"
 
 . "./patchUtil.ps1"
 
@@ -20,15 +25,17 @@ if (!(Test-Path $patchSDKFolder/dotnet-install.sh)) {
 }
 
 sudo chmod u+x $patchSDKFolder/dotnet-install.sh
-& $patchSDKFolder/dotnet-install.sh -i $patchSDKFolder -c master -v $SDKVersion -NoPath
+& $patchSDKFolder/dotnet-install.sh -InstallDir $patchSDKFolder -Channel $SDKChannel -Version $SDKVersion -NoPath
 
         
 $DOTNET = Join-Path -Path $patchSDKFolder -ChildPath 'dotnet'
+# Set DOTNET_MULTILEVEL_LOOKUP to 0 so it will just check the version in the specific path.
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
 # Display current version
 & $DOTNET --version
-$DownloadedSDKVersion = & $DOTNET --version
+$SDKVersion = & $DOTNET --version
 
-$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $DownloadedSDKVersion -nupkgsPath $nupkgsPath
+$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $SDKVersion -nupkgsPath $nupkgsPath
 
 if ($result -eq $true)
 {

--- a/SDKPatchTool/patchOnWindows.ps1
+++ b/SDKPatchTool/patchOnWindows.ps1
@@ -10,7 +10,7 @@ $SDKVersion = "latest"
 # Channel name of SDK. Pls refer to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options
 # "Current" - Most current release (For now, it's 5.x)
 # "main" - Branch name of a preview channel (For now, it's 6.x)
-$SDKChannel = "Current"
+$SDKChannel = "main"
 
 . ".\patchUtil.ps1"
 

--- a/SDKPatchTool/patchOnWindows.ps1
+++ b/SDKPatchTool/patchOnWindows.ps1
@@ -5,7 +5,12 @@ $patchSDKFolder = "C:\PatchedSDK"
 $nupkgsPath = "C:\repos\NuGet.Client\artifacts\nupkgs"
 
 # SDKVersion is the version of dotnet/sdk which NuGet is inserting into.
-$SDKVersion = "5.0.100"
+$SDKVersion = "latest"
+
+# Channel name of SDK. Pls refer to https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options
+# "Current" - Most current release (For now, it's 5.x)
+# "main" - Branch name of a preview channel (For now, it's 6.x)
+$SDKChannel = "Current"
 
 . ".\patchUtil.ps1"
 
@@ -18,15 +23,17 @@ if (!(Test-Path $patchSDKFolder\dotnet-install.ps1)) {
     Invoke-WebRequest https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1 -OutFile $patchSDKFolder\dotnet-install.ps1
 }
 
-& $patchSDKFolder\dotnet-install.ps1 -i $patchSDKFolder -c master -v $SDKVersion -NoPath
+& $patchSDKFolder\dotnet-install.ps1 -InstallDir $patchSDKFolder -Channel $SDKChannel -Version $SDKVersion -NoPath
 
         
-$DOTNET = Join-Path -Path $patchSDKFolder -ChildPath 'dotnet'
+$DOTNET = Join-Path -Path $patchSDKFolder -ChildPath 'dotnet.exe'
+# Set DOTNET_MULTILEVEL_LOOKUP to 0 so it will just check the version in the specific path.
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
 # Display current version
 & $DOTNET --version
-$DownloadedSDKVersion = & $DOTNET --version
+$SDKVersion = & $DOTNET --version
 
-$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $DownloadedSDKVersion -nupkgsPath $nupkgsPath
+$result = Patch -patchSDKFolder $patchSDKFolder -SDKVersion $SDKVersion -nupkgsPath $nupkgsPath
 
 if ($result -eq $true)
 {

--- a/SDKPatchTool/patchUtil.ps1
+++ b/SDKPatchTool/patchUtil.ps1
@@ -71,7 +71,7 @@ function PatchNupkgs {
     }
     Write-host "Dll :  $patchDll will be used for patching."
 
-    #the destination of the dlls in nupkg should be dotnet/sdk/5.xx/
+    #the destination of the dlls in nupkg should be dotnet/sdk/x.yz/
     $destPath = [System.IO.Path]::Combine($patchSDKFolder, 'sdk', $SDKVersion)
     $dllName = $patchDll.Name
 


### PR DESCRIPTION
Made some changes to make the patching script work again.
There are a few changes in dotnet-install.ps1 script and dotnet sdk break the patching.
1. -i to -InstallDir
2. Add channel so that we could patch 5.x or  6.x by specifying "Current" or "main"
3. Fix a bug when using "latest" as the version
4. Add DOTNET_MULTILEVEL_LOOKUP = 0 to make sure the version is the one in the specified install path. (Make the script more robust)

Similar changes will be applied to unix script later.