### PR TITLE
make sure dirs are created before writing results

### DIFF
--- a/InsertionChangeLogGenerator/ChangeLogGenerator.cs
+++ b/InsertionChangeLogGenerator/ChangeLogGenerator.cs
@@ -121,6 +121,8 @@ namespace InsertionChangeLogGenerator
 
         public static void SaveAsHtml(IList<Commit> commits, string path)
         {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+
             if (File.Exists(path))
             {
                 File.Delete(path);


### PR DESCRIPTION
it was kinda annoying that I got an error just because the parent dir wasn't created so this should fix that.