### PR TITLE
Documentation validator now automatically finds relevant issues and creates new ones if needed

### DIFF
--- a/DocumentationValidator/DocumentationValidator.csproj
+++ b/DocumentationValidator/DocumentationValidator.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk" >
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <NuGetCommonVersion Condition= " '$(NuGetMajorMinorVersion)' != '' ">$(NuGetMajorMinorVersion).*-*</NuGetCommonVersion>
-    <NuGetCommonVersion Condition= " '$(NuGetCommonVersion)' == '' ">*-*</NuGetCommonVersion>
+    <NuGetCommonVersion Condition=" '$(NuGetMajorMinorVersion)' != '' ">$(NuGetMajorMinorVersion).*-*</NuGetCommonVersion>
+    <NuGetCommonVersion Condition=" '$(NuGetCommonVersion)' == '' ">*-*</NuGetCommonVersion>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Description>A utility for validating that relevant NuGet documentation has been published.</Description>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Common" Version="$(NuGetCommonVersion)" />
+    <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>
 
 </Project>

--- a/DocumentationValidator/DocumentationValidator.sln
+++ b/DocumentationValidator/DocumentationValidator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31717.71
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentationValidator", "DocumentationValidator.csproj", "{C24A193D-B62C-44EF-99B9-A3C475E813A8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C24A193D-B62C-44EF-99B9-A3C475E813A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C24A193D-B62C-44EF-99B9-A3C475E813A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C24A193D-B62C-44EF-99B9-A3C475E813A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C24A193D-B62C-44EF-99B9-A3C475E813A8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {719C6A99-4D85-4B65-AF4B-E0BFD56CCC70}
+	EndGlobalSection
+EndGlobal

--- a/DocumentationValidator/NuGet.Config
+++ b/DocumentationValidator/NuGet.Config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
For example, here's the output without the issue creation version.

| Log Code | Potential Issues | 
|----------|------------------| 
| NU1004 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/1257 | 
| NU1005 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/1257 | 
| NU1006 |  | 
| NU1007 |  | 
| NU1008 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2549 | 
| NU1009 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2549 | 
| NU1010 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2549 | 
| NU1011 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2549 | 
| NU1012 |  | 
| NU1109 |  | 
| NU1204 |  | 
| NU1211 |  | 
| NU1212 |  | 
| NU1213 |  | 
| NU1402 |  | 
| NU1403 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2026 | 
| NU1410 |  | 
| NU1702 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2544 | 
| NU3039 |  | 
| NU3041 |  | 
| NU5042 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2524 | 
| NU5045 |  | 
| NU5049 |  | 
| NU5050 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2332 | 
| NU5126 |  | 
| NU5132 | https://github.com/NuGet/docs.microsoft.com-nuget/issues/2301 | 
| NU5501 | https://github.com/NuGet/docs.microsoft.com-nuget/pull/2178, https://github.com/NuGet/docs.microsoft.com-nuget/issues/2177 |