### PR TITLE
skip type engineering issues from release notes

### DIFF
--- a/ChangelogGenerator/ChangelogGenerator/IssueLabels.cs
+++ b/ChangelogGenerator/ChangelogGenerator/IssueLabels.cs
@@ -10,7 +10,7 @@ namespace ChangelogGenerator
     {
         public static string ClosedPrefix = "Resolution:";
         public static string RegressionDuringThisVersion = "RegressionDuringThisVersion";
-        public static string EngImprovement = "Category:Engineering";
+        public static string EngImprovement = "Type:Engineering";
         public static string Epic = "Epic";
         public static string Feature = "Type:Feature";
         public static string DCR = "Type:DCR";


### PR DESCRIPTION
Addressing https://github.com/NuGet/docs.microsoft.com-nuget/pull/2667#discussion_r804926547 comment to exclude `Type:Engineering` issues from the release notes. I double checked to make sure we don't have any `Category:Engineering` label in Home or Client Engineering repo.