### PR TITLE
Skip Microsoft.Extensions.* assemblies when validating localization

### DIFF
--- a/NuGetBuildValidators/NuGetValidator.Utility/FileUtility.cs
+++ b/NuGetBuildValidators/NuGetValidator.Utility/FileUtility.cs
@@ -47,10 +47,21 @@ namespace NuGetValidator.Utility
             else
             {
                 return Directory.GetFiles(root, "*.dll", SearchOption.TopDirectoryOnly)
-                    .Where(f => Path.GetFileName(f).StartsWith("NuGet", StringComparison.OrdinalIgnoreCase) ||
-                                Path.GetFileName(f).StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase))
+                    .Where(ShouldIncludeDll)
                     .ToArray();
             }
+        }
+
+        public static bool ShouldIncludeDll(string filePath)
+        {
+            string fileName = Path.GetFileName(filePath);
+
+            if (fileName.StartsWith("Microsoft.Extensions.", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return fileName.StartsWith("NuGet", StringComparison.OrdinalIgnoreCase) || fileName.StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
This logic is causing errors when I get rid of submodules in NuGet.Client and are safe to ignore