### PR TITLE
Refactor GithubIssueTagger to split commands into classes

### DIFF
--- a/GithubIssueTagger/GithubIssueTagger.csproj
+++ b/GithubIssueTagger/GithubIssueTagger.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Octokit" Version="0.51.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
   </ItemGroup>
 
 </Project>

--- a/GithubIssueTagger/IssueUtilities.cs
+++ b/GithubIssueTagger/IssueUtilities.cs
@@ -10,7 +10,7 @@ namespace GithubIssueTagger
     {
         public static async Task GetIssuesRankedAsync(GitHubClient client, params string[] labels)
         {
-            var issues = await GetIssuesForLabels(client, "NuGet", "Home", labels);
+            var issues = await GetIssuesForLabelsAsync(client, "NuGet", "Home", labels);
             var allIssues = new List<IssueRankingModel>(issues.Count);
 
             var internalAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -63,6 +63,7 @@ namespace GithubIssueTagger
                     new Tuple<string, string>("Score", "Score"),
                 };
             }
+
             static async Task<double> CalculateScoreAsync(Issue issue, GitHubClient client, HashSet<string> internalAliases)
             {
                 int totalCommentsCount = issue.Comments;
@@ -91,7 +92,7 @@ namespace GithubIssueTagger
             }
         }
 
-        internal static async Task ReopenAutoclosedDocsRepoIssues(GitHubClient client)
+        internal static async Task ReopenAutoclosedDocsRepoIssuesAsync(GitHubClient client)
         {
             var nugetRepos = new RepositoryCollection();
             string owner = "nuget";
@@ -122,7 +123,7 @@ namespace GithubIssueTagger
             }
         }
 
-        public static async Task<IList<Issue>> GetIssuesForMilestone(GitHubClient client, string org, string repo, string milestone, Predicate<Issue> predicate)
+        public static async Task<IList<Issue>> GetIssuesForMilestoneAsync(GitHubClient client, string org, string repo, string milestone, Predicate<Issue> predicate)
         {
             var shouldPrioritize = new RepositoryIssueRequest
             {
@@ -135,20 +136,20 @@ namespace GithubIssueTagger
             return issuesForMilestone.Where(e => predicate(e)).ToList();
         }
 
-        public static async Task<IList<Issue>> GetIssuesForLabel(GitHubClient client, string org, string repo, string label)
+        public static async Task<IList<Issue>> GetIssuesForLabelAsync(GitHubClient client, string org, string repo, string label)
         {
-            var issuesForMilestone = await GetAllIssues(client, org, repo);
+            var issuesForMilestone = await GetAllIssuesAsync(client, org, repo);
             return issuesForMilestone.Where(e => HasLabel(e, label)).ToList();
         }
 
         // All labels need to be considered.
-        public static async Task<IList<Issue>> GetIssuesForLabels(GitHubClient client, string org, string repo, params string[] labels)
+        public static async Task<IList<Issue>> GetIssuesForLabelsAsync(GitHubClient client, string org, string repo, params string[] labels)
         {
-            var issuesForMilestone = await GetAllIssues(client, org, repo);
+            var issuesForMilestone = await GetAllIssuesAsync(client, org, repo);
             return issuesForMilestone.Where(e => labels.All(label => HasLabel(e, label))).ToList();
         }
 
-        public static async Task<IReadOnlyList<Issue>> GetAllIssues(GitHubClient client, string org, string repo)
+        public static async Task<IReadOnlyList<Issue>> GetAllIssuesAsync(GitHubClient client, string org, string repo)
         {
             var shouldPrioritize = new RepositoryIssueRequest
             {
@@ -159,7 +160,7 @@ namespace GithubIssueTagger
             return issuesForMilestone;
         }
 
-        public static async Task<IReadOnlyList<Issue>> GetOpenPriority1Issues(GitHubClient client, string org, string repo)
+        public static async Task<IReadOnlyList<Issue>> GetOpenPriority1IssuesAsync(GitHubClient client, string org, string repo)
         {
             var nugetRepos = new RepositoryCollection();
             nugetRepos.Add(org, repo);
@@ -179,7 +180,7 @@ namespace GithubIssueTagger
         /// <summary>
         /// Get all the issues considered unprocessed. This means that either the issue does not have any labels, or only has the pipeline labels.
         /// </summary>
-        public static async Task<IList<Issue>> GetUnprocessedIssues(GitHubClient client, string org, string repo)
+        public static async Task<IList<Issue>> GetUnprocessedIssuesAsync(GitHubClient client, string org, string repo)
         {
             var shouldPrioritize = new RepositoryIssueRequest
             {
@@ -196,7 +197,7 @@ namespace GithubIssueTagger
             }
         }
 
-        public static async Task AddLabelToMatchingIssues(GitHubClient client, string label, string org, string repo, Predicate<Issue> predicate)
+        public static async Task AddLabelToMatchingIssuesAsync(GitHubClient client, string label, string org, string repo, Predicate<Issue> predicate)
         {
             var issuesForRepo = await client.Issue.GetAllForRepository(org, repo);
 

--- a/GithubIssueTagger/IssueUtilities.cs
+++ b/GithubIssueTagger/IssueUtilities.cs
@@ -148,7 +148,7 @@ namespace GithubIssueTagger
             return issuesForMilestone.Where(e => labels.All(label => HasLabel(e, label))).ToList();
         }
 
-        public static async Task<IEnumerable<Issue>> GetAllIssues(GitHubClient client, string org, string repo)
+        public static async Task<IReadOnlyList<Issue>> GetAllIssues(GitHubClient client, string org, string repo)
         {
             var shouldPrioritize = new RepositoryIssueRequest
             {
@@ -159,7 +159,7 @@ namespace GithubIssueTagger
             return issuesForMilestone;
         }
 
-        public static async Task<IEnumerable<Issue>> GetOpenPriority1Issues(GitHubClient client, string org, string repo)
+        public static async Task<IReadOnlyList<Issue>> GetOpenPriority1Issues(GitHubClient client, string org, string repo)
         {
             var nugetRepos = new RepositoryCollection();
             nugetRepos.Add(org, repo);

--- a/GithubIssueTagger/PlanningUtilities.cs
+++ b/GithubIssueTagger/PlanningUtilities.cs
@@ -27,8 +27,8 @@ namespace GithubIssueTagger
 
         public static async Task<IEnumerable<Issue>> GetPackageSourceMappingFeatureIssues(GitHubClient client)
         {
-            var homeIssues = await IssueUtilities.GetIssuesForLabels(client, "nuget", "home", SourceMappingLabel, TypeFeatureLabel);
-            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabels(client, "nuget", "client.engineering", SourceMappingLabel, TypeFeatureLabel);
+            var homeIssues = await IssueUtilities.GetIssuesForLabelsAsync(client, "nuget", "home", SourceMappingLabel, TypeFeatureLabel);
+            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabelsAsync(client, "nuget", "client.engineering", SourceMappingLabel, TypeFeatureLabel);
             var issues = (homeIssues.Union(clientEngineeringIssues)).ToList();
 
             return issues;
@@ -36,8 +36,8 @@ namespace GithubIssueTagger
 
         public static async Task<IEnumerable<Issue>> GetPackageSourceMappingDesign(GitHubClient client)
         {
-            var homeIssues = await IssueUtilities.GetIssuesForLabels(client, "nuget", "home", SourceMappingLabel, TypeSpec);
-            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabels(client, "nuget", "client.engineering", SourceMappingLabel, TypeSpec);
+            var homeIssues = await IssueUtilities.GetIssuesForLabelsAsync(client, "nuget", "home", SourceMappingLabel, TypeSpec);
+            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabelsAsync(client, "nuget", "client.engineering", SourceMappingLabel, TypeSpec);
             var issues = (homeIssues.Union(clientEngineeringIssues)).ToList();
 
             return issues;
@@ -46,9 +46,9 @@ namespace GithubIssueTagger
         public static async Task<IEnumerable<Issue>> GetPackageSourceMappingIssuesForSprint(GitHubClient client)
         {
             static bool isRelevant(Issue x) => IsPackageSourceMappingIssue(x);
-            var clientEngineeringIssues = await IssueUtilities.GetIssuesForMilestone(client, "nuget", "client.engineering", "34", isRelevant);
+            var clientEngineeringIssues = await IssueUtilities.GetIssuesForMilestoneAsync(client, "nuget", "client.engineering", "34", isRelevant);
             // 2021-11 is 131 in Home and 2021-11 is 34 on Client.Engineering
-            var homeIssues = await IssueUtilities.GetIssuesForMilestone(client, "nuget", "home", "131", isRelevant);
+            var homeIssues = await IssueUtilities.GetIssuesForMilestoneAsync(client, "nuget", "home", "131", isRelevant);
             var issues = (homeIssues.Union(clientEngineeringIssues)).ToList();
 
             return issues;
@@ -56,8 +56,8 @@ namespace GithubIssueTagger
 
         public static async Task<IList<Issue>> GetAllPackageSourceMappingIssues(GitHubClient client)
         {
-            var homeIssues = await IssueUtilities.GetIssuesForLabel(client, "nuget", "home", SourceMappingLabel);
-            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabel(client, "nuget", "client.engineering", SourceMappingLabel);
+            var homeIssues = await IssueUtilities.GetIssuesForLabelAsync(client, "nuget", "home", SourceMappingLabel);
+            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabelAsync(client, "nuget", "client.engineering", SourceMappingLabel);
             var issues = (homeIssues.Union(clientEngineeringIssues)).ToList();
 
             return issues;
@@ -67,9 +67,9 @@ namespace GithubIssueTagger
         {
             Predicate<Issue> isRelevant = (Issue x) => IsPerformance(x);
             // 111 is Sprint 173
-            var homeIssues = await IssueUtilities.GetIssuesForMilestone(client, "nuget", "home", "111", isRelevant);
+            var homeIssues = await IssueUtilities.GetIssuesForMilestoneAsync(client, "nuget", "home", "111", isRelevant);
             // 15 is Sprint 173
-            var clientEngineeringIssues = await IssueUtilities.GetIssuesForMilestone(client, "nuget", "client.engineering", "15", isRelevant);
+            var clientEngineeringIssues = await IssueUtilities.GetIssuesForMilestoneAsync(client, "nuget", "client.engineering", "15", isRelevant);
             var issues = homeIssues.Union(clientEngineeringIssues);
 
             return issues;
@@ -90,7 +90,7 @@ namespace GithubIssueTagger
         {
             Predicate<Issue> isRelevant = (Issue x) => IsEngineeringExcellence(x);
             // 13 is Sprint 171
-            var issues = await IssueUtilities.GetIssuesForMilestone(client, "nuget", "client.engineering", "13", isRelevant);
+            var issues = await IssueUtilities.GetIssuesForMilestoneAsync(client, "nuget", "client.engineering", "13", isRelevant);
 
             return issues;
 
@@ -103,8 +103,8 @@ namespace GithubIssueTagger
 
         public static async Task<IEnumerable<Issue>> GetPerformanceBacklog(GitHubClient client)
         {
-            var homeIssues = await IssueUtilities.GetIssuesForLabel(client, "nuget", "home", "Tenet:Performance");
-            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabel(client, "nuget", "client.engineering", "Tenet:Performance");
+            var homeIssues = await IssueUtilities.GetIssuesForLabelAsync(client, "nuget", "home", "Tenet:Performance");
+            var clientEngineeringIssues = await IssueUtilities.GetIssuesForLabelAsync(client, "nuget", "client.engineering", "Tenet:Performance");
             var issues = homeIssues.Union(clientEngineeringIssues);
             return issues;
         }

--- a/GithubIssueTagger/Program.cs
+++ b/GithubIssueTagger/Program.cs
@@ -1,385 +1,144 @@
-﻿using CommandLine;
-using Newtonsoft.Json;
+﻿using GithubIssueTagger;
+using GithubIssueTagger.Reports;
+using Microsoft.Extensions.DependencyInjection;
 using Octokit;
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.CommandLine;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace GithubIssueTagger
+var allReportTypes = typeof(Program).Assembly.GetTypes().Where(t => t.IsClass && t.IsAssignableTo(typeof(IReport))).OrderBy(t => t.Name).ToList();
+
+var patOption = new Option<string>("--pat");
+patOption.AddAlias("-p");
+
+var interactiveCommand = new Command(
+"--interactive",
+"Run in interactive mode.");
+interactiveCommand.AddAlias("-i");
+interactiveCommand.SetHandler(
+    async (string pat) => await RunInteractiveMode(null, allReportTypes),
+    patOption);
+
+var rootCommand = new RootCommand
 {
-    public class Program
+    patOption,
+    interactiveCommand
+};
+
+patOption.Description = "GitHub Personal Access Token. If none is supplied, an attempt to get one from the git credential provider will be made.";
+rootCommand.Description = "NuGet.Client tool to generate reports from GitHub issues.";
+
+foreach (var reportType in allReportTypes)
+{
+    var reportCommand = new Command(reportType.Name);
+    reportCommand.SetHandler(async (string pat) =>
     {
-        private static IList<Issue> _unprocessedIssues;
-        private static IReadOnlyList<Label> _allHomeLabels;
-        private static IReadOnlyList<Label> _allClientEngineeringLabels;
-        private static IEnumerable<Issue> _allHomeIssues;
-        private static IEnumerable<Issue> _allClientEngineeringIssues;
-        private static GitHubClient _client;
+        var githubClient = GetGitHubClient(pat);
+        var serviceProvider = GetSericeProvider(githubClient, allReportTypes);
+        IReport report = (IReport)serviceProvider.GetRequiredService(reportType);
+        await report.Run();
+    }, patOption);
 
-        static int Main(string[] args)
+    rootCommand.AddCommand(reportCommand);
+}
+
+var exitCode = await rootCommand.InvokeAsync(args);
+return exitCode;
+
+static GitHubClient GetGitHubClient(string pat)
+{
+    var client = new GitHubClient(new ProductHeaderValue("nuget-github-issue-tagger"));
+
+    if (!string.IsNullOrEmpty(pat))
+    {
+        client.Credentials = new Credentials(pat);
+    }
+    else
+    {
+        Dictionary<string, string> credentuals = GitCredentials.Get(new Uri("https://github.com/NuGet/Home"));
+        if (credentuals?.TryGetValue("password", out string password) == true)
         {
-            return Parser.Default.ParseArguments<RunOptions>(args)
-               .MapResult(
-                 (RunOptions copyOptions) => RunCommand(copyOptions),
-                 errs => 1);
+            client.Credentials = new Credentials(password);
         }
-
-        private static int RunCommand(RunOptions opts)
+        else
         {
-            return RunCommandAsync(opts).GetAwaiter().GetResult();
+            Console.WriteLine("Warning: Unable to get github token. Making unauthenticated HTTP requests, which has lower request limits.");
         }
+    }
 
+    return client;
+}
 
-        [Verb("run", HelpText = "Generate an insertion changelog.")]
-        class RunOptions
+static IServiceProvider GetSericeProvider(GitHubClient githubClient, IEnumerable<Type> reports)
+{
+    var services = new ServiceCollection();
+
+    services.AddSingleton(githubClient);
+    services.AddSingleton<QueryCache>();
+
+    foreach (var report in reports)
+    {
+        services.AddSingleton(report);
+    }
+
+    IServiceProvider serviceProvider = services.BuildServiceProvider();
+    return serviceProvider;
+}
+
+static async Task RunInteractiveMode(string pat, IReadOnlyList<Type> reportTypes)
+{
+    var client = GetGitHubClient(pat);
+    var serviceProvider = GetSericeProvider(client, reportTypes);
+
+    Console.WriteLine("**********************************************************************");
+    Console.WriteLine("******************* NuGet GitHub Issue Tagger ************************");
+    Console.WriteLine("**********************************************************************");
+    Console.WriteLine();
+
+    for (; ; )
+    {
+        for (int i = 0; i < reportTypes.Count; i++)
         {
-            [Option("pat", Required = false, HelpText = "A Github PAT from a user with sufficient permissions to perform the invoked action.")]
-            public string PAT { get; set; }
-
-            [Option("prompt", Required = false, HelpText = "Whether to go into prompt mode.")]
-            public bool Prompt { get; set; }
+            Console.WriteLine("{0}: {1}", i, reportTypes[i].Name);
         }
+        Console.WriteLine("Enter a # to query or 'quit' to exit: ");
 
-        static async Task<int> RunCommandAsync(RunOptions opts)
+        var input = Console.ReadLine();
+
+        Type? reportToRun;
+        if (StringComparer.CurrentCultureIgnoreCase.Equals("quit", input))
         {
-            _client = new GitHubClient(new ProductHeaderValue("nuget-github-issue-tagger"));
-
-            if (!string.IsNullOrEmpty(opts.PAT))
+            return;
+        }
+        if (int.TryParse(input, out int index) && index >= 0 && index < reportTypes.Count)
+        {
+            reportToRun = reportTypes[index];
+        }
+        else
+        {
+            reportToRun = null;
+            for (int i = 0; i < reportTypes.Count; i++)
             {
-                _client.Credentials = new Credentials(opts.PAT);
-            }
-            else
-            {
-                Dictionary<string, string> credentuals = GitCredentials.Get(new Uri("https://github.com/NuGet/Home"));
-                if (credentuals?.TryGetValue("password", out string pat) == true)
+                if (StringComparer.CurrentCultureIgnoreCase.Equals(i, reportTypes[i].Name))
                 {
-                    _client.Credentials = new Credentials(pat);
-                }
-                else
-                {
-                    Console.WriteLine("Warning: Unable to get github token. Making unauthenticated HTTP requests, which has lower request limits.");
+                    reportToRun = reportTypes[i];
+                    break;
                 }
             }
-
-
-            if (opts.Prompt)
-            {
-                await PromptForQuery();
-            }
-            else //default
-            {
-                await AllUnprocessed();
-            }
-
-            return 0;
         }
 
-        private static async Task PromptForQuery()
+        if (reportToRun == null)
         {
-            Console.WriteLine("**********************************************************************");
-            Console.WriteLine("******************* NuGet GitHub Issue Tagger ************************");
-            Console.WriteLine("**********************************************************************");
-            Console.WriteLine();
-
-            do
-            {
-                Console.WriteLine("Enter a # to query:");
-                Console.WriteLine("1: " + nameof(AllUnprocessed));
-                Console.WriteLine("2: " + nameof(AllLabels));
-                Console.WriteLine("3: " + nameof(AreaLabels));
-                Console.WriteLine("4: " + nameof(AreaOwnerReport));
-                Console.WriteLine("5: " + nameof(ClientEngineeringPriority1Issues));
-                Console.WriteLine("6: " + nameof(HomePriority1Issues));
-            }
-            while (null != await RunQueryOrReturnUnknownInput(Console.ReadLine()));
+            Console.WriteLine("Unknown query '" + input + "'");
         }
-
-        private static async Task<string> RunQueryOrReturnUnknownInput(string v)
+        else
         {
-            if (v is null)
-                return string.Empty;
-            Console.Write("*** Executing... ");
-            string executedMethod = string.Empty;
-            switch (v.Trim())
-            {
-                case "1":
-                    executedMethod = nameof(AllUnprocessed);
-                    Console.WriteLine(executedMethod + "***");
-                    await AllUnprocessed();
-                    break;
-                case "2":
-                    executedMethod = nameof(AllLabels);
-                    Console.WriteLine(executedMethod + "***");
-                    await AllLabels();
-                    break;
-                case "3":
-                    executedMethod = nameof(AreaLabels);
-                    Console.WriteLine(executedMethod + "***");
-                    await AreaLabels();
-                    break;
-                case "4":
-                    executedMethod = nameof(AreaOwnerReport);
-                    Console.WriteLine(executedMethod + "***");
-                    await AreaOwnerReport();
-                    break;
-                case "5":
-                    executedMethod = nameof(ClientEngineeringPriority1Issues);
-                    Console.WriteLine(executedMethod + "***");
-                    await ClientEngineeringPriority1Issues();
-                    break;
-                case "6":
-                    executedMethod = nameof(HomePriority1Issues);
-                    Console.WriteLine(executedMethod + "***");
-                    await HomePriority1Issues();
-                    break;
-                case "quit":
-                    return null;
-                default:
-                    break;
-            }
-            Console.WriteLine("*** Done Executing " + executedMethod + " ***");
-            return string.Empty;
+            Console.WriteLine(reportToRun.Name + "***");
+            var report = (IReport)serviceProvider.GetRequiredService(reportToRun);
+            await report.Run();
+            Console.WriteLine("*** Done Executing " + reportToRun.Name + " ***");
         }
-
-        private static async Task AllUnprocessed()
-        {
-            if (_unprocessedIssues is null)
-            {
-                _unprocessedIssues = await IssueUtilities.GetUnprocessedIssues(_client, "nuget", "home");
-            }
-            foreach (var issue in _unprocessedIssues)
-            {
-                Console.WriteLine(issue.HtmlUrl);
-            }
-        }
-
-        private static async Task AllLabels()
-        {
-            if (_allHomeLabels is null)
-            {
-                _allHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
-            }
-            Console.WriteLine("(ID\tName)");
-            foreach (var label in _allHomeLabels)
-            {
-                Console.WriteLine(label.Id + "\t" + label.Name);
-            }
-        }
-
-        private static async Task AreaLabels()
-        {
-            IEnumerable<Label> areaLabels = await GetAreaLabels();
-            Console.WriteLine("(ID\tName)");
-            foreach (var label in areaLabels)
-            {
-                Console.WriteLine(label.Id + "\t" + label.Name);
-            }
-        }
-
-        private static async Task AreaOwnerReport()
-        {
-            if (_allHomeIssues is null)
-            {
-                _allHomeIssues = await IssueUtilities.GetAllIssues(_client, "nuget", "home");
-            }
-
-            if (_allHomeLabels is null)
-            {
-                _allHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
-            }
-
-            List<Label> ignoreLabels = new List<Label>()
-            {
-                //2671458320      Type:Tracking
-                _allHomeLabels.SingleOrDefault(label => label.Id == 2671458320),
-
-                //801160517       Type: Spec
-                _allHomeLabels.SingleOrDefault(label => label.Id == 801160517),
-
-                //1593926950      Type: DeveloperDocs
-                _allHomeLabels.SingleOrDefault(label => label.Id == 1593926950),
-
-                //249737088       Type: Docs
-                _allHomeLabels.SingleOrDefault(label => label.Id == 249737088),
-
-                //180116592       Type: Feature
-                _allHomeLabels.SingleOrDefault(label => label.Id == 180116592),
-
-                //2185215650      Type: Learning
-                _allHomeLabels.SingleOrDefault(label => label.Id == 2185215650),
-            };
-
-            List<Label> validTypeLabels = new List<Label>()
-            {
-                //180116450       Type:Bug
-                _allHomeLabels.SingleOrDefault(label => label.Id == 180116450),
-
-                //386656158       Type: DataAnalysis
-                _allHomeLabels.SingleOrDefault(label => label.Id == 386656158),
-
-                //180970997       Type: DCR
-                _allHomeLabels.SingleOrDefault(label => label.Id == 180970997),
-
-                //979424473       Type: Test
-                _allHomeLabels.SingleOrDefault(label => label.Id == 979424473),
-            };
-
-            IEnumerable<Issue> includedIssues = _allHomeIssues.Where(issue => !issue.Labels.Any(label => ignoreLabels.Any(ignoreLabel => ignoreLabel.Id == label.Id)));
-
-            //263262236       Functionality:VisualStudioUI = PM UI
-            Label pmuiLabel = await GetLabelById(263262236);
-            IEnumerable<Issue> pmuiIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == pmuiLabel.Id));
-            Console.WriteLine("PM UI\t" + pmuiIssues.Count() + GetUntypedIssueCountString(pmuiIssues, validTypeLabels));
-
-            //430506461       Product: VS.PMConsole = PMC
-            Label pmcLabel = await GetLabelById(430506461);
-            IEnumerable<Issue> pmcIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == pmcLabel.Id));
-            Console.WriteLine("PMC\t" + pmcIssues.Count() + GetUntypedIssueCountString(pmcIssues, validTypeLabels));
-
-            //171462728       Functionality: SDK = SDK
-            Label sdkLabel = await GetLabelById(171462728);
-            IEnumerable<Issue> sdkIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == sdkLabel.Id));
-            Console.WriteLine("SDK\t" + sdkIssues.Count() + GetUntypedIssueCountString(sdkIssues, validTypeLabels));
-
-            //CLI(nuget, dotnet, msbuild)
-            //{
-            //    722811433       Product: dotnet.exe
-            //    182924875       Product: NuGet.exe
-            //    1048477918      Product: MSBuildSDKResolver
-            //}
-            Label cliLabel1 = await GetLabelById(722811433);
-            Label cliLabel2 = await GetLabelById(182924875);
-            Label cliLabel3 = await GetLabelById(1048477918);
-            var cliLabels = new long[] { cliLabel1.Id, cliLabel2.Id, cliLabel3.Id };
-            IEnumerable<Issue> cliIssues = includedIssues.Where(issue => issue.Labels.Any(label => cliLabels.Contains(label.Id)));
-            Console.WriteLine("CLI\t" + cliIssues.Count() + GetUntypedIssueCountString(cliIssues, validTypeLabels));
-
-            //330852328       Functionality: Pack = Pack
-            Label packLabel = await GetLabelById(330852328);
-            IEnumerable<Issue> packIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == packLabel.Id));
-            Console.WriteLine("Pack\t" + packIssues.Count() + GetUntypedIssueCountString(packIssues, validTypeLabels));
-
-            //332553843       Functionality: Push = Push
-            Label pushLabel = await GetLabelById(332553843);
-            IEnumerable<Issue> pushIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == pushLabel.Id));
-            Console.WriteLine("Push\t" + pushIssues.Count() + GetUntypedIssueCountString(pushIssues, validTypeLabels));
-
-            //Restore
-            //{
-            //    345983287       Functionality: Restore
-            //    1950335805      Area: RestoreCPVM
-            //    630044219       Area: RestoreNoOp
-            //    1243121573      Area: RestoreRepeatableBuild
-            //    1790102601      Area: RestoreStaticGraph
-            //    664611674       Area: RestoreTool
-            //}
-            Label restoreLabel1 = await GetLabelById(345983287);
-            Label restoreLabel2 = await GetLabelById(1950335805);
-            Label restoreLabel3 = await GetLabelById(630044219);
-            Label restoreLabel4 = await GetLabelById(1243121573);
-            Label restoreLabel5 = await GetLabelById(1790102601);
-            Label restoreLabel6 = await GetLabelById(664611674);
-            var restoreLabels = new long[] { restoreLabel1.Id, restoreLabel2.Id, restoreLabel3.Id, restoreLabel4.Id, restoreLabel5.Id, restoreLabel6.Id };
-            IEnumerable<Issue> restoreIssues = includedIssues.Where(issue => issue.Labels.Any(label => restoreLabels.Contains(label.Id)));
-            Console.WriteLine("Restore\t" + restoreIssues.Count() + GetUntypedIssueCountString(restoreIssues, validTypeLabels));
-
-            // 702649610       Functionality: Signing = Signing / verification
-            Label signingLabel = await GetLabelById(702649610);
-            IEnumerable<Issue> signingIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == signingLabel.Id));
-            Console.WriteLine("Signing\t" + signingIssues.Count() + GetUntypedIssueCountString(signingIssues, validTypeLabels));
-
-            //Package Management(install/ uninstall / update)
-            //{
-            //    430514155       Functionality: Install
-            //    336427001       Functionality: Update
-            //}
-            Label managementLabel1 = await GetLabelById(430514155);
-            Label managementLabel2 = await GetLabelById(336427001);
-            var managementLabels = new long[] { managementLabel1.Id, managementLabel2.Id };
-            IEnumerable<Issue> managementIssues = includedIssues.Where(issue => issue.Labels.Any(label => managementLabels.Contains(label.Id)));
-            Console.WriteLine("Package Management\t" + managementIssues.Count() + GetUntypedIssueCountString(managementIssues, validTypeLabels));
-
-            //Search + List
-            //{
-            //    1498027322      Functionality: List(Search)
-            //    723045456       Functionality: Search
-            //}
-            Label searchListLabel1 = await GetLabelById(1498027322);
-            Label searchListLabel2 = await GetLabelById(723045456);
-            var searchListLabels = new long[] { searchListLabel1.Id, searchListLabel2.Id };
-            IEnumerable<Issue> searchListIssues = includedIssues.Where(issue => issue.Labels.Any(label => searchListLabels.Contains(label.Id)));
-            Console.WriteLine("Search & List\t" + searchListIssues.Count() + GetUntypedIssueCountString(searchListIssues, validTypeLabels));
-
-            //    723058565       Area: NewFrameworks = Core
-            Label coreLabel = await GetLabelById(723058565);
-            IEnumerable<Issue> coreIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == coreLabel.Id));
-            Console.WriteLine("Core\t" + coreIssues.Count() + GetUntypedIssueCountString(coreIssues, validTypeLabels));
-        }
-
-        private static async Task ClientEngineeringPriority1Issues()
-        {
-            if (_allClientEngineeringIssues is null)
-            {
-                _allClientEngineeringIssues = await IssueUtilities.GetOpenPriority1Issues(_client, "nuget", "client.engineering");
-            }
-
-            var outputFileName = "clientEngineeringIssues.json";
-            var json = JsonConvert.SerializeObject(_allClientEngineeringIssues, Formatting.Indented);
-            File.WriteAllText(outputFileName, json);
-
-            Console.WriteLine(nameof(ClientEngineeringPriority1Issues) + " wrote to " + outputFileName);
-        }
-
-        private static async Task HomePriority1Issues()
-        {
-            if (_allHomeIssues is null)
-            {
-                _allHomeIssues = await IssueUtilities.GetOpenPriority1Issues(_client, "nuget", "home");
-            }
-
-            var outputFileName = "homeIssues.json";
-            var json = JsonConvert.SerializeObject(_allHomeIssues, Formatting.Indented);
-            File.WriteAllText(outputFileName, json);
-
-            Console.WriteLine(nameof(HomePriority1Issues) + " wrote to " + outputFileName);
-        }
-
-        private static string GetUntypedIssueCountString(IEnumerable<Issue> issues, List<Label> validTypeLabels)
-        {
-            IEnumerable<long> validTypeLabelIds = validTypeLabels.Select(label => label.Id);
-            IEnumerable<Issue> unlabeledIssues = issues.Where(issue => !issue.Labels.Any(label => validTypeLabelIds.Contains(label.Id)));
-            var unlabeledCount = unlabeledIssues.Count();
-            if (unlabeledCount > 0)
-            {
-                return " (Missing Types: " + unlabeledCount + ")";
-            }
-            return string.Empty;
-        }
-
-        #region Helpers
-        private static async Task<IEnumerable<Label>> GetAreaLabels()
-        {
-            if (_allHomeLabels is null)
-            {
-                _allHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
-            }
-
-            IEnumerable<Label> areaLabels = _allHomeLabels?.Where(l => l.Name.StartsWith("Area:", StringComparison.OrdinalIgnoreCase));
-            return areaLabels;
-        }
-
-        private static async Task<Label> GetLabelById(long id)
-        {
-            if (_allHomeLabels is null)
-            {
-                _allHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
-            }
-
-            Label foundLabel = _allHomeLabels?.SingleOrDefault(l => l.Id == id);
-            return foundLabel;
-        }
-        #endregion
     }
 }

--- a/GithubIssueTagger/Program.cs
+++ b/GithubIssueTagger/Program.cs
@@ -18,7 +18,7 @@ var interactiveCommand = new Command(
 "Run in interactive mode.");
 interactiveCommand.AddAlias("-i");
 interactiveCommand.SetHandler(
-    async (string pat) => await RunInteractiveMode(null, allReportTypes),
+    async (string pat) => await RunInteractiveModeAsync(null, allReportTypes),
     patOption);
 
 var rootCommand = new RootCommand
@@ -36,9 +36,9 @@ foreach (var reportType in allReportTypes)
     reportCommand.SetHandler(async (string pat) =>
     {
         var githubClient = GetGitHubClient(pat);
-        var serviceProvider = GetSericeProvider(githubClient, allReportTypes);
+        var serviceProvider = GetServiceProvider(githubClient, allReportTypes);
         IReport report = (IReport)serviceProvider.GetRequiredService(reportType);
-        await report.Run();
+        await report.RunAsync();
     }, patOption);
 
     rootCommand.AddCommand(reportCommand);
@@ -71,7 +71,7 @@ static GitHubClient GetGitHubClient(string pat)
     return client;
 }
 
-static IServiceProvider GetSericeProvider(GitHubClient githubClient, IEnumerable<Type> reports)
+static IServiceProvider GetServiceProvider(GitHubClient githubClient, IEnumerable<Type> reports)
 {
     var services = new ServiceCollection();
 
@@ -87,10 +87,10 @@ static IServiceProvider GetSericeProvider(GitHubClient githubClient, IEnumerable
     return serviceProvider;
 }
 
-static async Task RunInteractiveMode(string pat, IReadOnlyList<Type> reportTypes)
+static async Task RunInteractiveModeAsync(string pat, IReadOnlyList<Type> reportTypes)
 {
     var client = GetGitHubClient(pat);
-    var serviceProvider = GetSericeProvider(client, reportTypes);
+    var serviceProvider = GetServiceProvider(client, reportTypes);
 
     Console.WriteLine("**********************************************************************");
     Console.WriteLine("******************* NuGet GitHub Issue Tagger ************************");
@@ -107,7 +107,7 @@ static async Task RunInteractiveMode(string pat, IReadOnlyList<Type> reportTypes
 
         var input = Console.ReadLine();
 
-        Type? reportToRun;
+        Type reportToRun;
         if (StringComparer.CurrentCultureIgnoreCase.Equals("quit", input))
         {
             return;
@@ -137,7 +137,7 @@ static async Task RunInteractiveMode(string pat, IReadOnlyList<Type> reportTypes
         {
             Console.WriteLine(reportToRun.Name + "***");
             var report = (IReport)serviceProvider.GetRequiredService(reportToRun);
-            await report.Run();
+            await report.RunAsync();
             Console.WriteLine("*** Done Executing " + reportToRun.Name + " ***");
         }
     }

--- a/GithubIssueTagger/QueryCache.cs
+++ b/GithubIssueTagger/QueryCache.cs
@@ -1,0 +1,11 @@
+﻿using Octokit;
+using System.Collections.Generic;
+
+namespace GithubIssueTagger
+{
+    internal class QueryCache
+    {
+        public IReadOnlyList<Label> AllHomeLabels { get; set; }
+        public IReadOnlyList<Issue> AllHomeIssues { get; set; }
+    }
+}

--- a/GithubIssueTagger/Reports/AllLabels.cs
+++ b/GithubIssueTagger/Reports/AllLabels.cs
@@ -15,7 +15,7 @@ namespace GithubIssueTagger.Reports
             _client = client;
         }
 
-        public async Task Run()
+        public async Task RunAsync()
         {
             if (_allHomeLabels is null)
             {

--- a/GithubIssueTagger/Reports/AllLabels.cs
+++ b/GithubIssueTagger/Reports/AllLabels.cs
@@ -1,0 +1,31 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GithubIssueTagger.Reports
+{
+    internal class AllLabels : IReport
+    {
+        private GitHubClient _client;
+        private static IReadOnlyList<Label> _allHomeLabels;
+
+        public AllLabels(GitHubClient client)
+        {
+            _client = client;
+        }
+
+        public async Task Run()
+        {
+            if (_allHomeLabels is null)
+            {
+                _allHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
+            }
+            Console.WriteLine("(ID\tName)");
+            foreach (var label in _allHomeLabels)
+            {
+                Console.WriteLine(label.Id + "\t" + label.Name);
+            }
+        }
+    }
+}

--- a/GithubIssueTagger/Reports/AllUnprocessed.cs
+++ b/GithubIssueTagger/Reports/AllUnprocessed.cs
@@ -15,11 +15,11 @@ namespace GithubIssueTagger.Reports
             _client = client;
         }
 
-        public async Task Run()
+        public async Task RunAsync()
         {
             if (_unprocessedIssues is null)
             {
-                _unprocessedIssues = await IssueUtilities.GetUnprocessedIssues(_client, "nuget", "home");
+                _unprocessedIssues = await IssueUtilities.GetUnprocessedIssuesAsync(_client, "nuget", "home");
             }
             foreach (var issue in _unprocessedIssues)
             {

--- a/GithubIssueTagger/Reports/AllUnprocessed.cs
+++ b/GithubIssueTagger/Reports/AllUnprocessed.cs
@@ -1,0 +1,30 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GithubIssueTagger.Reports
+{
+    internal class AllUnprocessed : IReport
+    {
+        private GitHubClient _client;
+        private static IList<Issue> _unprocessedIssues;
+
+        public AllUnprocessed(GitHubClient client)
+        {
+            _client = client;
+        }
+
+        public async Task Run()
+        {
+            if (_unprocessedIssues is null)
+            {
+                _unprocessedIssues = await IssueUtilities.GetUnprocessedIssues(_client, "nuget", "home");
+            }
+            foreach (var issue in _unprocessedIssues)
+            {
+                Console.WriteLine(issue.HtmlUrl);
+            }
+        }
+    }
+}

--- a/GithubIssueTagger/Reports/AreaLabels.cs
+++ b/GithubIssueTagger/Reports/AreaLabels.cs
@@ -1,0 +1,41 @@
+﻿using Octokit;
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace GithubIssueTagger.Reports
+{
+    internal class AreaLabels : IReport
+    {
+        private GitHubClient _client;
+        private QueryCache _queryCache;
+
+        public AreaLabels(GitHubClient client, QueryCache queryCache)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _queryCache = queryCache ?? throw new ArgumentNullException(nameof(queryCache));
+        }
+
+        public async Task Run()
+        {
+            IEnumerable<Label> areaLabels = await GetAreaLabels();
+            Console.WriteLine("(ID\tName)");
+            foreach (var label in areaLabels)
+            {
+                Console.WriteLine(label.Id + "\t" + label.Name);
+            }
+        }
+
+        private async Task<IEnumerable<Label>> GetAreaLabels()
+        {
+            if (_queryCache.AllHomeLabels is null)
+            {
+                _queryCache.AllHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
+            }
+
+            IEnumerable<Label> areaLabels = _queryCache.AllHomeLabels?.Where(l => l.Name.StartsWith("Area:", StringComparison.OrdinalIgnoreCase));
+            return areaLabels;
+        }
+    }
+}

--- a/GithubIssueTagger/Reports/AreaLabels.cs
+++ b/GithubIssueTagger/Reports/AreaLabels.cs
@@ -17,7 +17,7 @@ namespace GithubIssueTagger.Reports
             _queryCache = queryCache ?? throw new ArgumentNullException(nameof(queryCache));
         }
 
-        public async Task Run()
+        public async Task RunAsync()
         {
             IEnumerable<Label> areaLabels = await GetAreaLabels();
             Console.WriteLine("(ID\tName)");

--- a/GithubIssueTagger/Reports/AreaOwnerReport.cs
+++ b/GithubIssueTagger/Reports/AreaOwnerReport.cs
@@ -1,0 +1,184 @@
+﻿using Octokit;
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace GithubIssueTagger.Reports
+{
+    internal class AreaOwnerReport : IReport
+    {
+        private GitHubClient _client;
+        private QueryCache _queryCache;
+
+        public AreaOwnerReport(GitHubClient client, QueryCache queryCache)
+        {
+            _client = client;
+            _queryCache = queryCache;
+        }
+
+        public async Task Run()
+        {
+            if (_queryCache.AllHomeIssues is null)
+            {
+                _queryCache.AllHomeIssues = await IssueUtilities.GetAllIssues(_client, "nuget", "home");
+            }
+
+            if (_queryCache.AllHomeLabels is null)
+            {
+                _queryCache.AllHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
+            }
+
+            List<Label> ignoreLabels = new List<Label>()
+            {
+                //2671458320      Type:Tracking
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 2671458320),
+
+                //801160517       Type: Spec
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 801160517),
+
+                //1593926950      Type: DeveloperDocs
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 1593926950),
+
+                //249737088       Type: Docs
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 249737088),
+
+                //180116592       Type: Feature
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 180116592),
+
+                //2185215650      Type: Learning
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 2185215650),
+            };
+
+            List<Label> validTypeLabels = new List<Label>()
+            {
+                //180116450       Type:Bug
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 180116450),
+
+                //386656158       Type: DataAnalysis
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 386656158),
+
+                //180970997       Type: DCR
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 180970997),
+
+                //979424473       Type: Test
+                _queryCache.AllHomeLabels.SingleOrDefault(label => label.Id == 979424473),
+            };
+
+            IEnumerable<Issue> includedIssues = _queryCache.AllHomeIssues.Where(issue => !issue.Labels.Any(label => ignoreLabels.Any(ignoreLabel => ignoreLabel.Id == label.Id)));
+
+            //263262236       Functionality:VisualStudioUI = PM UI
+            Label pmuiLabel = await GetLabelById(263262236);
+            IEnumerable<Issue> pmuiIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == pmuiLabel.Id));
+            Console.WriteLine("PM UI\t" + pmuiIssues.Count() + GetUntypedIssueCountString(pmuiIssues, validTypeLabels));
+
+            //430506461       Product: VS.PMConsole = PMC
+            Label pmcLabel = await GetLabelById(430506461);
+            IEnumerable<Issue> pmcIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == pmcLabel.Id));
+            Console.WriteLine("PMC\t" + pmcIssues.Count() + GetUntypedIssueCountString(pmcIssues, validTypeLabels));
+
+            //171462728       Functionality: SDK = SDK
+            Label sdkLabel = await GetLabelById(171462728);
+            IEnumerable<Issue> sdkIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == sdkLabel.Id));
+            Console.WriteLine("SDK\t" + sdkIssues.Count() + GetUntypedIssueCountString(sdkIssues, validTypeLabels));
+
+            //CLI(nuget, dotnet, msbuild)
+            //{
+            //    722811433       Product: dotnet.exe
+            //    182924875       Product: NuGet.exe
+            //    1048477918      Product: MSBuildSDKResolver
+            //}
+            Label cliLabel1 = await GetLabelById(722811433);
+            Label cliLabel2 = await GetLabelById(182924875);
+            Label cliLabel3 = await GetLabelById(1048477918);
+            var cliLabels = new long[] { cliLabel1.Id, cliLabel2.Id, cliLabel3.Id };
+            IEnumerable<Issue> cliIssues = includedIssues.Where(issue => issue.Labels.Any(label => cliLabels.Contains(label.Id)));
+            Console.WriteLine("CLI\t" + cliIssues.Count() + GetUntypedIssueCountString(cliIssues, validTypeLabels));
+
+            //330852328       Functionality: Pack = Pack
+            Label packLabel = await GetLabelById(330852328);
+            IEnumerable<Issue> packIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == packLabel.Id));
+            Console.WriteLine("Pack\t" + packIssues.Count() + GetUntypedIssueCountString(packIssues, validTypeLabels));
+
+            //332553843       Functionality: Push = Push
+            Label pushLabel = await GetLabelById(332553843);
+            IEnumerable<Issue> pushIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == pushLabel.Id));
+            Console.WriteLine("Push\t" + pushIssues.Count() + GetUntypedIssueCountString(pushIssues, validTypeLabels));
+
+            //Restore
+            //{
+            //    345983287       Functionality: Restore
+            //    1950335805      Area: RestoreCPVM
+            //    630044219       Area: RestoreNoOp
+            //    1243121573      Area: RestoreRepeatableBuild
+            //    1790102601      Area: RestoreStaticGraph
+            //    664611674       Area: RestoreTool
+            //}
+            Label restoreLabel1 = await GetLabelById(345983287);
+            Label restoreLabel2 = await GetLabelById(1950335805);
+            Label restoreLabel3 = await GetLabelById(630044219);
+            Label restoreLabel4 = await GetLabelById(1243121573);
+            Label restoreLabel5 = await GetLabelById(1790102601);
+            Label restoreLabel6 = await GetLabelById(664611674);
+            var restoreLabels = new long[] { restoreLabel1.Id, restoreLabel2.Id, restoreLabel3.Id, restoreLabel4.Id, restoreLabel5.Id, restoreLabel6.Id };
+            IEnumerable<Issue> restoreIssues = includedIssues.Where(issue => issue.Labels.Any(label => restoreLabels.Contains(label.Id)));
+            Console.WriteLine("Restore\t" + restoreIssues.Count() + GetUntypedIssueCountString(restoreIssues, validTypeLabels));
+
+            // 702649610       Functionality: Signing = Signing / verification
+            Label signingLabel = await GetLabelById(702649610);
+            IEnumerable<Issue> signingIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == signingLabel.Id));
+            Console.WriteLine("Signing\t" + signingIssues.Count() + GetUntypedIssueCountString(signingIssues, validTypeLabels));
+
+            //Package Management(install/ uninstall / update)
+            //{
+            //    430514155       Functionality: Install
+            //    336427001       Functionality: Update
+            //}
+            Label managementLabel1 = await GetLabelById(430514155);
+            Label managementLabel2 = await GetLabelById(336427001);
+            var managementLabels = new long[] { managementLabel1.Id, managementLabel2.Id };
+            IEnumerable<Issue> managementIssues = includedIssues.Where(issue => issue.Labels.Any(label => managementLabels.Contains(label.Id)));
+            Console.WriteLine("Package Management\t" + managementIssues.Count() + GetUntypedIssueCountString(managementIssues, validTypeLabels));
+
+            //Search + List
+            //{
+            //    1498027322      Functionality: List(Search)
+            //    723045456       Functionality: Search
+            //}
+            Label searchListLabel1 = await GetLabelById(1498027322);
+            Label searchListLabel2 = await GetLabelById(723045456);
+            var searchListLabels = new long[] { searchListLabel1.Id, searchListLabel2.Id };
+            IEnumerable<Issue> searchListIssues = includedIssues.Where(issue => issue.Labels.Any(label => searchListLabels.Contains(label.Id)));
+            Console.WriteLine("Search & List\t" + searchListIssues.Count() + GetUntypedIssueCountString(searchListIssues, validTypeLabels));
+
+            //    723058565       Area: NewFrameworks = Core
+            Label coreLabel = await GetLabelById(723058565);
+            IEnumerable<Issue> coreIssues = includedIssues.Where(issue => issue.Labels.Any(label => label.Id == coreLabel.Id));
+            Console.WriteLine("Core\t" + coreIssues.Count() + GetUntypedIssueCountString(coreIssues, validTypeLabels));
+        }
+
+
+        private async Task<Label> GetLabelById(long id)
+        {
+            if (_queryCache.AllHomeLabels is null)
+            {
+                _queryCache.AllHomeLabels = await LabelUtilities.GetLabelsForRepository(_client, "nuget", "home");
+            }
+
+            Label foundLabel = _queryCache.AllHomeLabels?.SingleOrDefault(l => l.Id == id);
+            return foundLabel;
+        }
+
+        private static string GetUntypedIssueCountString(IEnumerable<Issue> issues, List<Label> validTypeLabels)
+        {
+            IEnumerable<long> validTypeLabelIds = validTypeLabels.Select(label => label.Id);
+            IEnumerable<Issue> unlabeledIssues = issues.Where(issue => !issue.Labels.Any(label => validTypeLabelIds.Contains(label.Id)));
+            var unlabeledCount = unlabeledIssues.Count();
+            if (unlabeledCount > 0)
+            {
+                return " (Missing Types: " + unlabeledCount + ")";
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/GithubIssueTagger/Reports/AreaOwnerReport.cs
+++ b/GithubIssueTagger/Reports/AreaOwnerReport.cs
@@ -17,11 +17,11 @@ namespace GithubIssueTagger.Reports
             _queryCache = queryCache;
         }
 
-        public async Task Run()
+        public async Task RunAsync()
         {
             if (_queryCache.AllHomeIssues is null)
             {
-                _queryCache.AllHomeIssues = await IssueUtilities.GetAllIssues(_client, "nuget", "home");
+                _queryCache.AllHomeIssues = await IssueUtilities.GetAllIssuesAsync(_client, "nuget", "home");
             }
 
             if (_queryCache.AllHomeLabels is null)

--- a/GithubIssueTagger/Reports/ClientEngineeringPriority1Issues.cs
+++ b/GithubIssueTagger/Reports/ClientEngineeringPriority1Issues.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace GithubIssueTagger.Reports
+{
+    internal class ClientEngineeringPriority1Issues : IReport
+    {
+        private GitHubClient _client;
+        private static IEnumerable<Issue> _allClientEngineeringIssues;
+
+        public ClientEngineeringPriority1Issues(GitHubClient client)
+        {
+            _client = client;
+        }
+
+        public async Task Run()
+        {
+            if (_allClientEngineeringIssues is null)
+            {
+                _allClientEngineeringIssues = await IssueUtilities.GetOpenPriority1Issues(_client, "nuget", "client.engineering");
+            }
+
+            var outputFileName = "clientEngineeringIssues.json";
+            var json = JsonConvert.SerializeObject(_allClientEngineeringIssues, Formatting.Indented);
+            File.WriteAllText(outputFileName, json);
+
+            Console.WriteLine(nameof(ClientEngineeringPriority1Issues) + " wrote to " + outputFileName);
+        }
+    }
+}

--- a/GithubIssueTagger/Reports/ClientEngineeringPriority1Issues.cs
+++ b/GithubIssueTagger/Reports/ClientEngineeringPriority1Issues.cs
@@ -17,11 +17,11 @@ namespace GithubIssueTagger.Reports
             _client = client;
         }
 
-        public async Task Run()
+        public async Task RunAsync()
         {
             if (_allClientEngineeringIssues is null)
             {
-                _allClientEngineeringIssues = await IssueUtilities.GetOpenPriority1Issues(_client, "nuget", "client.engineering");
+                _allClientEngineeringIssues = await IssueUtilities.GetOpenPriority1IssuesAsync(_client, "nuget", "client.engineering");
             }
 
             var outputFileName = "clientEngineeringIssues.json";

--- a/GithubIssueTagger/Reports/HomePriority1Issues.cs
+++ b/GithubIssueTagger/Reports/HomePriority1Issues.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using Octokit;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace GithubIssueTagger.Reports
+{
+    internal class HomePriority1Issues : IReport
+    {
+        private GitHubClient _client;
+        private QueryCache _queryCache;
+
+        public HomePriority1Issues(GitHubClient client, QueryCache queryCache)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _queryCache = queryCache ?? throw new ArgumentNullException(nameof(queryCache));
+        }
+
+        public async Task Run()
+        {
+            if (_queryCache.AllHomeIssues is null)
+            {
+                _queryCache.AllHomeIssues = await IssueUtilities.GetOpenPriority1Issues(_client, "nuget", "home");
+            }
+
+            var outputFileName = "homeIssues.json";
+            var json = JsonConvert.SerializeObject(_queryCache.AllHomeIssues, Formatting.Indented);
+            File.WriteAllText(outputFileName, json);
+
+            Console.WriteLine(nameof(HomePriority1Issues) + " wrote to " + outputFileName);
+        }
+    }
+}

--- a/GithubIssueTagger/Reports/HomePriority1Issues.cs
+++ b/GithubIssueTagger/Reports/HomePriority1Issues.cs
@@ -17,11 +17,11 @@ namespace GithubIssueTagger.Reports
             _queryCache = queryCache ?? throw new ArgumentNullException(nameof(queryCache));
         }
 
-        public async Task Run()
+        public async Task RunAsync()
         {
             if (_queryCache.AllHomeIssues is null)
             {
-                _queryCache.AllHomeIssues = await IssueUtilities.GetOpenPriority1Issues(_client, "nuget", "home");
+                _queryCache.AllHomeIssues = await IssueUtilities.GetOpenPriority1IssuesAsync(_client, "nuget", "home");
             }
 
             var outputFileName = "homeIssues.json";

--- a/GithubIssueTagger/Reports/IReport.cs
+++ b/GithubIssueTagger/Reports/IReport.cs
@@ -4,6 +4,6 @@ namespace GithubIssueTagger.Reports
 {
     internal interface IReport
     {
-        Task Run();
+        Task RunAsync();
     }
 }

--- a/GithubIssueTagger/Reports/IReport.cs
+++ b/GithubIssueTagger/Reports/IReport.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace GithubIssueTagger.Reports
+{
+    internal interface IReport
+    {
+        Task Run();
+    }
+}


### PR DESCRIPTION
There are some breaking changes:

1. I changed `--prompt` to `--interactive` (or `-i`)
2. In interactive mode, the numbers for the queries/reports have changed. They're now sorted lexographically.
3. It's no longer possible to run the command without any arguments (there's no default report)

This PR is primarily about making the tool more maintainable as more people want to add more reports. I created an `IReport` interface, and extracted the 6 reports into classes that implement this interface. I added basic DI to auto-discover the reports and create instances, so in theory adding a new report is just added a class that extends the interface.

I also switched to System.CommandLine, as I'm more familiar with that library (it's what the dotnet cli uses, and what NuGet.CommandLine.XPlat has been asked to migrate to).