### PR TITLE
Changelog generator uses GitHub milestones instead of ZenHub releases

### DIFF
--- a/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.cs
+++ b/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.cs
@@ -43,11 +43,11 @@ namespace ChangelogGenerator
             return GenerateMarkdown(Options.Release, issues);
         }
 
-        public static async Task<IList<Issue>> GetIssuesForMilestone(GitHubClient client, string org, string repo, string milestone)
+        public static async Task<IList<Issue>> GetIssuesForMilestone(GitHubClient client, string org, string repo, Milestone milestone)
         {
             var shouldPrioritize = new RepositoryIssueRequest
             {
-                Milestone = milestone,
+                Milestone = milestone.Number.ToString(),
                 Filter = IssueFilter.All,
                 State = ItemStateFilter.All,
             };
@@ -65,7 +65,7 @@ namespace ChangelogGenerator
 
             Milestone relevantMilestone = await FindMatchingMilestone(releaseId, org, repo);
 
-            var issueList = await GetIssuesForMilestone(GitHubClient, org, repo, relevantMilestone.Number.ToString());
+            var issueList = await GetIssuesForMilestone(GitHubClient, org, repo, relevantMilestone);
 
             foreach (Issue issue in issueList)
             {

--- a/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
+++ b/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <InstallFrom>Disk</InstallFrom>
     <MapFileExtensions>true</MapFileExtensions>

--- a/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
+++ b/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <InstallFrom>Disk</InstallFrom>
     <MapFileExtensions>true</MapFileExtensions>

--- a/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
+++ b/ChangelogGenerator/ChangelogGenerator/ChangelogGenerator.csproj
@@ -21,6 +21,5 @@
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="zenhub.net" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/ChangelogGenerator/ChangelogGenerator/GitCredentials.cs
+++ b/ChangelogGenerator/ChangelogGenerator/GitCredentials.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ChangelogGenerator
+{
+    internal class GitCredentials
+    {
+        // Implement https://git-scm.com/docs/git-credential#_typical_use_of_git_credential
+        public static Dictionary<string, string> Get(Uri uri)
+        {
+            string description = "url=" + uri.AbsoluteUri + "\n\n";
+
+            ProcessStartInfo processStartInfo = new()
+            {
+                FileName = "git",
+                Arguments = "credential fill",
+                CreateNoWindow = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+            };
+            processStartInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+
+            Process process = Process.Start(processStartInfo);
+            process.StandardInput.Write(description);
+
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                // unable to get credentials
+                return null;
+            }
+
+            Dictionary<string, string> result = new();
+            string line;
+            while ((line = process.StandardOutput.ReadLine()) != null)
+            {
+                int index = line.IndexOf('=');
+                if (index == -1)
+                {
+                    continue;
+                }
+
+                string key = line.Substring(0, index);
+                string value = line.Substring(index + 1);
+                result[key] = value;
+            }
+
+            return result.Count > 0 ? result : null;
+        }
+    }
+}

--- a/ChangelogGenerator/ChangelogGenerator/IssueType.cs
+++ b/ChangelogGenerator/ChangelogGenerator/IssueType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ChangelogGenerator
+﻿namespace ChangelogGenerator
 {
     public enum IssueType
     {

--- a/ChangelogGenerator/ChangelogGenerator/Options.cs
+++ b/ChangelogGenerator/ChangelogGenerator/Options.cs
@@ -12,7 +12,7 @@ namespace ChangelogGenerator
         [Value(1, Required = true, HelpText = "Release version to generate a changelog for.")]
         public string Release { get; set; }
 
-        [Option('g', "github-token", Required = true, HelpText = "GitHub Token for Auth.")]
+        [Option('g', "github-token", Required = false, HelpText = "GitHub Token for Auth. If not specified, it will acquired automatically.")]
         public string GitHubToken { get; set; }
 
 
@@ -27,7 +27,7 @@ namespace ChangelogGenerator
             {
                 return new List<Example>()
                 {
-                    new Example("Generate changelog for a particular release", new Options { Repo = "NuGet/Home", Release = "5.6", GitHubToken = "asdf", ZenHubToken = "hjkl" })
+                    new Example("Generate changelog for a particular release", new Options { Repo = "NuGet/Home", Release = "6.3", GitHubToken = "asdf" })
                 };
             }
         }

--- a/ChangelogGenerator/ChangelogGenerator/Options.cs
+++ b/ChangelogGenerator/ChangelogGenerator/Options.cs
@@ -15,14 +15,9 @@ namespace ChangelogGenerator
         [Option('g', "github-token", Required = true, HelpText = "GitHub Token for Auth.")]
         public string GitHubToken { get; set; }
 
-        [Option('z', "zenhub-token", Required = true, HelpText = "ZenHub Token for Auth.")]
-        public string ZenHubToken { get; set; }
 
         [Option('l', "label", HelpText = "Show only those issues from the selected release that have this label.")]
         public string RequiredLabel { get; set; }
-
-        [Option('v', "verbose", HelpText = "Print details during execution.")]
-        public bool Verbose { get; set; }
 
 
         [Usage(ApplicationAlias = "changelog-generator")]


### PR DESCRIPTION
Fixes https://github.com/NuGet/Client.Engineering/issues/1616

Example what happens if we run it for 6.3

I'll update the release notes playbook as well.

```md
---
title: NuGet 6.3 Release Notes
description: Release notes for NuGet 6.3 including new features, bug fixes, and DCRs.
author: <GithubAlias>
ms.author: <MicrosoftAlias>
ms.date: 5/20/2022
ms.topic: conceptual
---

# NuGet 6.3 Release Notes

NuGet distribution vehicles:

| NuGet version | Available in Visual Studio version | Available in .NET SDK(s) |
|:---|:---|:---|
| [**<NuGetVersion>**](https://nuget.org/downloads) | [Visual Studio <VSYear> version <VSVersion>](https://visualstudio.microsoft.com/downloads/) | [<SDKVersion>](https://dotnet.microsoft.com/download/dotnet-core/<SDKMajorMinorVersionOnly>)<sup>1</sup> |

<sup>1</sup> Installed with Visual Studio <VSYear> with.NET Core workload

## Summary: What's New in 6.3

* Create experimentation metrics to measure engagement of transitive dependencies - [#10759](https://github.com/NuGet/Home/issues/10759)

* Enhance the experimentation infrastructure in NuGet code to support transitive dependencies - [#10758](https://github.com/NuGet/Home/issues/10758)

* [Feature] Error on multiple entries for the same package ids in Directory.Packages.props - [#9467](https://github.com/NuGet/Home/issues/9467)

### Issues fixed in this release

**DCRs:**

* For C++/CLI PackageReference projects, NuGet should ignore the TargetPlatformMoniker - [#11808](https://github.com/NuGet/Home/issues/11808)

* PackageSourceMapping public constructor - [#11609](https://github.com/NuGet/Home/issues/11609)

**Bugs:**

* [Bug]: Visual Studio restore sometimes sets originalTargetFrameworks incorrectly in project.assets.json - [#11795](https://github.com/NuGet/Home/issues/11795)

* [Bug]: NuGet does not retry some HTTP timeouts - [#11779](https://github.com/NuGet/Home/issues/11779)

* Update SPDX licenses to bb0099c - [#11765](https://github.com/NuGet/Home/issues/11765)

* NuGet Package Manager window causes persistent WPF frame rate spike due to a runaway animation - [#11746](https://github.com/NuGet/Home/issues/11746)

* Large number of allocations while processing package references - [#11733](https://github.com/NuGet/Home/issues/11733)

* Unnecessary Allocations in SemanticVersion.ParseSections() - [#11732](https://github.com/NuGet/Home/issues/11732)

* Transitive lock files (with wildcard) result in NU1004 - [#8465](https://github.com/NuGet/Home/issues/8465)

**StillOpens:**

* [Bug]: [Bug Bash] The “Version” dropdown box is blank in “Consolidate” tab of solution-level PM UI - [#11806](https://github.com/NuGet/Home/issues/11806)

* [Bug]: The Latest Stable version does not show in the "Version" dropdown box after installing a package with not the latest version in “Updates” tab - [#11802](https://github.com/NuGet/Home/issues/11802)

* RestoreLockedMode=true & RestoreForceEvaluate=true should error - [#8222](https://github.com/NuGet/Home/issues/8222)

* NuGet.Commands embedded copy of FileSystemGlobbing is now public - [#2345](https://github.com/NuGet/Home/issues/2345)

```