### PR TITLE
make gitlogger more robust (Do not crash or choose wrong PR number wh…

### DIFF
--- a/InsertionChangeLogGenerator/ChangeLogGenerator.cs
+++ b/InsertionChangeLogGenerator/ChangeLogGenerator.cs
@@ -48,9 +48,13 @@ namespace InsertionChangeLogGenerator
 
             static int GetPRId(string message)
             {
-                foreach (Match match in new Regex(@"(#\d+)", RegexOptions.IgnoreCase).Matches(message))
+                //use RegexOptions.RightToLeft to match from the right side, to ignore the other numbers in the title
+                //E.g. 	Fix spelling of Wiederherstellen (NuGet/Home#11774) (#4591)
+                //Or, Revert "Disable timing out EndToEnd tests (#4592)" (#4597) Fixes https://github.com/NuGet/Client.Engineering/issues/1572 This reverts commit acee7c1c1773e3d96ca806b10ba068dd09b0baf5.
+                foreach (Match match in new Regex(@"\(#\d+\)", RegexOptions.RightToLeft).Matches(message))
                 {
-                    var pullRequestIdText = match.Value.Substring(1, match.Length - 1);
+                    // match={(#4634)}, pullRequestsIdText=4634
+                    var pullRequestIdText = match.Value.Substring(2, match.Length - 3);
                     int.TryParse(pullRequestIdText, out int prId);
                     return prId;
                 }


### PR DESCRIPTION
Make gitlogger more robust. Change the regex matching pattern to (#1234), and match from left to right

Previously, when identifying PR number from PR title, the following scenarios will fail:
1. When PR title is `Fix spelling of Wiederherstellen (NuGet/Home#11774) (#4591)`, the 11774 will be identified as PR number, then it would throw exception as it doesn't exist.
2. When PR title is `Revert "Disable timing out EndToEnd tests (#4592)" (#4597) Fixes https://github.com/NuGet/Client.Engineering/issues/1572 This reverts commit acee7c1c1773e3d96ca806b10ba068dd09b0baf5.`, the 4592 will be identified as the PR number but it's incorrect.