### PR TITLE
MakeTestCert:  CLI for creating test code signing certificates

### DIFF
--- a/MakeTestCert/.editorconfig
+++ b/MakeTestCert/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# IDE0063: Use simple 'using' statement
+csharp_prefer_simple_using_statement = false

--- a/MakeTestCert/MakeTestCert.csproj
+++ b/MakeTestCert/MakeTestCert.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>MakeTestCert</AssemblyName>
+    <TargetFramework>net7.0</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <Features>strict</Features>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/MakeTestCert/MakeTestCert.sln
+++ b/MakeTestCert/MakeTestCert.sln
@@ -1,0 +1,30 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.32721.557
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MakeTestCert", "MakeTestCert.csproj", "{E855E1BD-F47A-4E0B-988C-6AABF674888B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3C0F6001-D836-4232-B164-295E85F2A064}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E855E1BD-F47A-4E0B-988C-6AABF674888B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E855E1BD-F47A-4E0B-988C-6AABF674888B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E855E1BD-F47A-4E0B-988C-6AABF674888B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E855E1BD-F47A-4E0B-988C-6AABF674888B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8C8B5DF0-C553-469C-ABFD-D1658B285BEF}
+	EndGlobalSection
+EndGlobal

--- a/MakeTestCert/Oids.cs
+++ b/MakeTestCert/Oids.cs
@@ -1,0 +1,14 @@
+using System.Security.Cryptography;
+
+namespace MakeTestCert
+{
+    internal static class Oids
+    {
+        internal static readonly Oid CodeSigningEku = new(DottedDecimalValues.CodeSigningEku);
+
+        private static class DottedDecimalValues
+        {
+            internal const string CodeSigningEku = "1.3.6.1.5.5.7.3.3";
+        }
+    }
+}

--- a/MakeTestCert/Program.cs
+++ b/MakeTestCert/Program.cs
@@ -1,0 +1,312 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MakeTestCert
+{
+    internal static class Program
+    {
+        private const int Success = 0;
+        private const int Error = 1;
+
+        private static readonly ECCurve DefaultECCurve = ECCurve.NamedCurves.nistP256;
+        private static readonly HashAlgorithmName DefaultHashAlgorithmName = HashAlgorithmName.SHA384;
+        private static readonly string DefaultKeyAlgorithmName = "RSA";
+        private static readonly ushort DefaultKeySizeInBits = 3072;
+        private static readonly X500DistinguishedName DefaultSubject = new("CN=NuGet testing");
+        private static readonly ushort DefaultValidityPeriodInHours = 2;
+
+        private static int Main(string[] args)
+        {
+            try
+            {
+                return MainCore(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+
+                return Error;
+            }
+        }
+
+        private static int MainCore(string[] args)
+        {
+            if (args.Any(arg =>
+                string.Equals(arg, "-?", StringComparison.Ordinal)
+                    || string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase)))
+            {
+                PrintHelp();
+
+                return Success;
+            }
+
+            HashAlgorithmName hashAlgorithmName = DefaultHashAlgorithmName;
+            string keyAlgorithmName = DefaultKeyAlgorithmName;
+            ushort keySizeInBits = DefaultKeySizeInBits;
+            ECCurve namedCurve = DefaultECCurve;
+            DateTimeOffset? notAfter = null;
+            DateTimeOffset notBefore = DateTimeOffset.Now;
+            DirectoryInfo outputDirectory = new(".");
+            string? password = null;
+            X500DistinguishedName subject = DefaultSubject;
+
+            int argsCount = args.Length;
+
+            for (var i = 0; i < argsCount - 1; i += 2)
+            {
+                string arg = args[i].ToLowerInvariant();
+                string nextArg = args[i + 1];
+
+                switch (arg)
+                {
+                    case "-ka":
+                    case "--key-algorithm":
+                        keyAlgorithmName = nextArg;
+                        break;
+
+                    case "-ks":
+                    case "--key-size":
+                        keySizeInBits = ushort.Parse(nextArg);
+                        break;
+
+                    case "-na":
+                    case "--not-after":
+                        notAfter = DateTimeOffset.Parse(nextArg);
+                        break;
+
+                    case "-nb":
+                    case "--not-before":
+                        notBefore = DateTimeOffset.Parse(nextArg);
+                        break;
+
+                    case "-nc":
+                    case "--named-curve":
+                        if (string.Equals(nextArg, "nistP256", StringComparison.OrdinalIgnoreCase))
+                        {
+                            namedCurve = ECCurve.NamedCurves.nistP256;
+                        }
+                        else if (string.Equals(nextArg, "nistP384", StringComparison.OrdinalIgnoreCase))
+                        {
+                            namedCurve = ECCurve.NamedCurves.nistP384;
+                        }
+                        else if (string.Equals(nextArg, "nistP521", StringComparison.OrdinalIgnoreCase))
+                        {
+                            namedCurve = ECCurve.NamedCurves.nistP521;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Named curve '{nextArg}' is unsupported.");
+                            Console.WriteLine();
+
+                            PrintHelp();
+
+                            return Error;
+                        }
+                        break;
+
+                    case "-od":
+                    case "--output-directory":
+                        outputDirectory = new DirectoryInfo(nextArg);
+                        break;
+
+                    case "-p":
+                    case "--password":
+                        password = nextArg;
+                        break;
+
+                    case "-s":
+                    case "--subject":
+                        subject = new X500DistinguishedName(nextArg);
+                        break;
+
+                    default:
+                        PrintHelp();
+
+                        return Error;
+                }
+            }
+
+            notAfter ??= notBefore.AddHours(DefaultValidityPeriodInHours);
+
+            // Ensure the directory exists.
+            outputDirectory.Create();
+
+            if (string.Equals(keyAlgorithmName, "RSA", StringComparison.OrdinalIgnoreCase))
+            {
+                using (RSA keyPair = RSA.Create(keySizeInBits))
+                {
+                    CertificateRequest certificateRequest = new(
+                        subject,
+                        keyPair,
+                        hashAlgorithmName,
+                        RSASignaturePadding.Pkcs1);
+
+                    Console.WriteLine($"Signature algorithm:    RSA {hashAlgorithmName}");
+                    Console.WriteLine($"Key size (bits):        {keySizeInBits}");
+
+                    certificateRequest.CertificateExtensions.Add(
+                        new X509SubjectKeyIdentifierExtension(
+                            keyPair.ExportSubjectPublicKeyInfo(),
+                            critical: false));
+
+                    CreateCertificate(
+                        certificateRequest,
+                        notBefore,
+                        notAfter.Value,
+                        password,
+                        outputDirectory);
+                }
+            }
+            else if (string.Equals(keyAlgorithmName, "ECDSA", StringComparison.OrdinalIgnoreCase))
+            {
+                using (ECDsa keyPair = ECDsa.Create(namedCurve))
+                {
+                    CertificateRequest certificateRequest = new(
+                        subject,
+                        keyPair,
+                        hashAlgorithmName);
+
+                    Console.WriteLine($"Signature algorithm:    ECDSA {hashAlgorithmName}");
+                    Console.WriteLine($"Named curve:            {namedCurve.Oid.FriendlyName}");
+
+                    certificateRequest.CertificateExtensions.Add(
+                        new X509SubjectKeyIdentifierExtension(
+                            certificateRequest.PublicKey,
+                            critical: false));
+
+                    CreateCertificate(
+                        certificateRequest,
+                        notBefore,
+                        notAfter.Value,
+                        password,
+                        outputDirectory);
+                }
+            }
+            else
+            {
+                Console.Error.WriteLine($"Key algorithm '{keyAlgorithmName}' is unsupported.");
+                Console.WriteLine();
+
+                PrintHelp();
+
+                return Error;
+            }
+
+            return Success;
+        }
+
+        private static void PrintHelp()
+        {
+            FileInfo file = new(Environment.ProcessPath!);
+
+            Console.WriteLine($"Usage:  {file.Name} [option(s)]");
+            Console.WriteLine();
+            Console.WriteLine("  Option                   Description                                          Default");
+            Console.WriteLine("  ------------------------ ---------------------------------------------------- -----------------");
+            Console.WriteLine($"  --key-algorithm, -ka     signature key algorithm (RSA or ECDSA)               {DefaultKeyAlgorithmName}");
+            Console.WriteLine($"  --key-size, -ks          RSA key size in bits                                 {DefaultKeySizeInBits}");
+            Console.WriteLine($"  --named-curve, -nc       ECDSA named curve (nistP256, nistP384, or nistP521)  {DefaultECCurve.Oid.FriendlyName}");
+            Console.WriteLine($"  --not-after, -na         validity period end datetime                         (now)");
+            Console.WriteLine($"  --not-before, -nb        validity period start datetime                       (now + {DefaultValidityPeriodInHours} hours)");
+            Console.WriteLine($"  --password, -p           PFX file password                                    (none)");
+            Console.WriteLine($"  --output-directory, -od  output directory path                                .{Path.DirectorySeparatorChar}");
+            Console.WriteLine($"  --subject, -s            certificate subject                                  {DefaultSubject.Name}");
+            Console.WriteLine();
+            Console.WriteLine("Examples:");
+            Console.WriteLine();
+            Console.WriteLine($"  {file.Name}");
+            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for {DefaultValidityPeriodInHours} hours from creation time.");
+            Console.WriteLine();
+            Console.WriteLine($"  {file.Name} -nb \"2022-08-01 08:00\" -na \"2022-08-01 16:00\"");
+            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for the specified local time period.");
+            Console.WriteLine();
+            Console.WriteLine($"  {file.Name} -od .{Path.DirectorySeparatorChar}certs");
+            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for {DefaultValidityPeriodInHours} hours in the 'certs' subdirectory.");
+            Console.WriteLine();
+            Console.WriteLine($"  {file.Name} -ks 4096 -s CN=untrusted");
+            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} 4096-bit certificate valid for {DefaultValidityPeriodInHours} hours with the subject 'CN=untrusted'.");
+        }
+
+        private static void CreateCertificate(
+            CertificateRequest certificateRequest,
+            DateTimeOffset notBefore,
+            DateTimeOffset notAfter,
+            string? password,
+            DirectoryInfo outputDirectory)
+        {
+            certificateRequest.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: true,
+                    hasPathLengthConstraint: false,
+                    pathLengthConstraint: 0,
+                    critical: true));
+            certificateRequest.CertificateExtensions.Add(
+                new X509EnhancedKeyUsageExtension(
+                    new OidCollection() { Oids.CodeSigningEku },
+                    critical: true));
+            certificateRequest.CertificateExtensions.Add(
+                new X509KeyUsageExtension(
+                    X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyCertSign,
+                    critical: true));
+
+            using (X509Certificate2 certificate = certificateRequest.CreateSelfSigned(notBefore, notAfter))
+            {
+                string fingerprint = certificate.GetCertHashString().ToLowerInvariant();
+
+                Console.WriteLine($"NotBefore:              {certificate.NotBefore:yyyy-MM-dd HH:mm:ssK}");
+                Console.WriteLine($"NotAfter:               {certificate.NotAfter:yyyy-MM-dd HH:mm:ssK}");
+                Console.WriteLine($"Fingerprint (SHA-1):    {fingerprint}");
+                Console.WriteLine($"Fingerprint (SHA-256):  {certificate.GetCertHashString(HashAlgorithmName.SHA256).ToLowerInvariant()}");
+                Console.WriteLine($"PFX password:           {(string.IsNullOrEmpty(password) ? string.Empty : password)}");
+                Console.WriteLine($"Output directory:       {outputDirectory.FullName}");
+                Console.WriteLine("Certificate files:");
+
+                WritePfxFile(certificate, outputDirectory, fingerprint, password);
+                WriteDerFile(certificate, outputDirectory, fingerprint);
+                WritePemFile(certificate, outputDirectory, fingerprint);
+            }
+        }
+
+        private static void WriteDerFile(X509Certificate2 certificate, DirectoryInfo directory, string fileName)
+        {
+            FileInfo file = new(Path.Combine(directory.FullName, $"{fileName}.cer"));
+
+            File.WriteAllBytes(file.FullName, certificate.RawData);
+
+            Console.WriteLine($"    {file.Name}");
+        }
+
+        private static void WritePemFile(X509Certificate2 certificate, DirectoryInfo directory, string fileName)
+        {
+            FileInfo file = new(Path.Combine(directory.FullName, $"{fileName}.pem"));
+
+            File.WriteAllText(file.FullName, certificate.ExportCertificatePem());
+
+            Console.WriteLine($"    {file.Name}");
+        }
+
+        private static void WritePfxFile(
+            X509Certificate2 certificate,
+            DirectoryInfo directory,
+            string fileName,
+            string? password)
+        {
+            FileInfo file = new(Path.Combine(directory.FullName, $"{fileName}.pfx"));
+            byte[] bytes;
+
+            if (string.IsNullOrEmpty(password))
+            {
+                bytes = certificate.Export(X509ContentType.Pfx);
+            }
+            else
+            {
+                bytes = certificate.Export(X509ContentType.Pfx, password);
+            }
+
+            File.WriteAllBytes(file.FullName, bytes);
+
+            Console.WriteLine($"    {file.Name}");
+        }
+    }
+}


### PR DESCRIPTION
The existing PowerShell script [CreateTestCertificate.ps1](https://github.com/NuGet/Entropy/blob/main/TestCertGenerator/CreateTestCertificate.ps1) is a pain because it only runs on Windows.  This means that for cross-platform testing, you first have to create a certificate on Windows and then copy it to a Linux or macOS machine.  What a hassle!

This tool is super simple and cross-platform.  Run it with no arguments to generate a self-issued code signing certificate or customize with options.

`MakeTestCert -?` output:

```text
Usage:  MakeTestCert.exe [option(s)]

  Option                   Description                                          Default
  ------------------------ ---------------------------------------------------- -----------------
  --key-algorithm, -ka     signature key algorithm (RSA or ECDSA)               RSA
  --key-size, -ks          RSA key size in bits                                 3072
  --named-curve, -nc       ECDSA named curve (nistP256, nistP384, or nistP521)  nistP256
  --not-after, -na         validity period end datetime                         (now)
  --not-before, -nb        validity period start datetime                       (now + 2 hours)
  --password, -p           PFX file password                                    (none)
  --output-directory, -od  output directory path                                .\
  --subject, -s            certificate subject                                  CN=NuGet testing

Examples:

  MakeTestCert.exe
    Creates an RSA 3072-bit certificate valid for 2 hours from creation time.

  MakeTestCert.exe -nb "2022-08-01 08:00" -na "2022-08-01 16:00"
    Creates an RSA 3072-bit certificate valid for the specified local time period.

  MakeTestCert.exe -od .\certs
    Creates an RSA 3072-bit certificate valid for 2 hours in the 'certs' subdirectory.

  MakeTestCert.exe -ks 4096 -s CN=untrusted
    Creates an RSA 4096-bit certificate valid for 2 hours with the subject 'CN=untrusted'.
```