### PR TITLE
TrustTestCert:  CLI for adding/removing trust for test code signing certificates

### DIFF
--- a/MakeTestCert/Oids.cs
+++ b/MakeTestCert/Oids.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Security.Cryptography;
 
 namespace MakeTestCert

--- a/MakeTestCert/Program.cs
+++ b/MakeTestCert/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
@@ -202,16 +205,16 @@ namespace MakeTestCert
 
             Console.WriteLine($"Usage:  {file.Name} [option(s)]");
             Console.WriteLine();
-            Console.WriteLine("  Option                   Description                                          Default");
-            Console.WriteLine("  ------------------------ ---------------------------------------------------- -----------------");
-            Console.WriteLine($"  --key-algorithm, -ka     signature key algorithm (RSA or ECDSA)               {DefaultKeyAlgorithmName}");
-            Console.WriteLine($"  --key-size, -ks          RSA key size in bits                                 {DefaultKeySizeInBits}");
-            Console.WriteLine($"  --named-curve, -nc       ECDSA named curve (nistP256, nistP384, or nistP521)  {DefaultECCurve.Oid.FriendlyName}");
-            Console.WriteLine($"  --not-after, -na         validity period end datetime                         (now)");
-            Console.WriteLine($"  --not-before, -nb        validity period start datetime                       (now + {DefaultValidityPeriodInHours} hours)");
-            Console.WriteLine($"  --password, -p           PFX file password                                    (none)");
-            Console.WriteLine($"  --output-directory, -od  output directory path                                .{Path.DirectorySeparatorChar}");
-            Console.WriteLine($"  --subject, -s            certificate subject                                  {DefaultSubject.Name}");
+            Console.WriteLine("  Option                   Description                     Default");
+            Console.WriteLine("  ------------------------ ------------------------------- -----------------");
+            Console.WriteLine($"  --key-algorithm, -ka     RSA or ECDSA                    {DefaultKeyAlgorithmName}");
+            Console.WriteLine($"  --key-size, -ks          RSA key size in bits            {DefaultKeySizeInBits}");
+            Console.WriteLine($"  --named-curve, -nc       ECDSA named curve               {DefaultECCurve.Oid.FriendlyName}");
+            Console.WriteLine($"  --not-after, -na         validity period end datetime    (now)");
+            Console.WriteLine($"  --not-before, -nb        validity period start datetime  (now + {DefaultValidityPeriodInHours} hours)");
+            Console.WriteLine($"  --password, -p           PFX file password               (none)");
+            Console.WriteLine($"  --output-directory, -od  output directory path           .{Path.DirectorySeparatorChar}");
+            Console.WriteLine($"  --subject, -s            certificate subject             {DefaultSubject.Name}");
             Console.WriteLine();
             Console.WriteLine("Examples:");
             Console.WriteLine();
@@ -219,13 +222,16 @@ namespace MakeTestCert
             Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for {DefaultValidityPeriodInHours} hours from creation time.");
             Console.WriteLine();
             Console.WriteLine($"  {file.Name} -nb \"2022-08-01 08:00\" -na \"2022-08-01 16:00\"");
-            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for the specified local time period.");
+            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for the specified local time ");
+            Console.WriteLine("    period.");
             Console.WriteLine();
             Console.WriteLine($"  {file.Name} -od .{Path.DirectorySeparatorChar}certs");
-            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for {DefaultValidityPeriodInHours} hours in the 'certs' subdirectory.");
+            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} {DefaultKeySizeInBits}-bit certificate valid for {DefaultValidityPeriodInHours} hours in the 'certs' ");
+            Console.WriteLine("    subdirectory.");
             Console.WriteLine();
             Console.WriteLine($"  {file.Name} -ks 4096 -s CN=untrusted");
-            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} 4096-bit certificate valid for {DefaultValidityPeriodInHours} hours with the subject 'CN=untrusted'.");
+            Console.WriteLine($"    Creates an {DefaultKeyAlgorithmName} 4096-bit certificate valid for {DefaultValidityPeriodInHours} hours with the subject ");
+            Console.WriteLine("    'CN=untrusted'.");
         }
 
         private static void CreateCertificate(
@@ -281,7 +287,13 @@ namespace MakeTestCert
         {
             FileInfo file = new(Path.Combine(directory.FullName, $"{fileName}.pem"));
 
-            File.WriteAllText(file.FullName, certificate.ExportCertificatePem());
+            // ExportCertificatePem() is available starting with .NET 7.
+            using (StreamWriter writer = new(file.FullName))
+            {
+                char[] pem = PemEncoding.Write("CERTIFICATE", certificate.RawData);
+
+                writer.WriteLine(pem);
+            }
 
             Console.WriteLine($"    {file.Name}");
         }

--- a/TrustTestCert/.editorconfig
+++ b/TrustTestCert/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# IDE0063: Use simple 'using' statement
+csharp_prefer_simple_using_statement = false

--- a/TrustTestCert/CertificateBundleUtilities.cs
+++ b/TrustTestCert/CertificateBundleUtilities.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace TrustTestCert
+{
+    internal static class CertificateBundleUtilities
+    {
+        internal static void AddCertificateToBundle(X509Certificate2 certificate, FileInfo certificateBundle)
+        {
+            ArgumentNullException.ThrowIfNull(certificate, nameof(certificate));
+            ArgumentNullException.ThrowIfNull(certificateBundle, nameof(certificateBundle));
+
+            X509Certificate2Collection certificates = new();
+
+            certificates.ImportFromPemFile(certificateBundle.FullName);
+
+            if (!certificates.Contains(certificate))
+            {
+                certificates.Add(certificate);
+
+                WriteCertificateBundle(certificates, certificateBundle);
+            }
+        }
+
+        internal static bool CertificateExistsInBundle(X509Certificate2 certificate, FileInfo certificateBundle)
+        {
+            ArgumentNullException.ThrowIfNull(certificate, nameof(certificate));
+            ArgumentNullException.ThrowIfNull(certificateBundle, nameof(certificateBundle));
+
+            X509Certificate2Collection certificates = new();
+
+            certificates.ImportFromPemFile(certificateBundle.FullName);
+
+            return certificates.Contains(certificate);
+        }
+
+        internal static void RemoveCertificateFromBundle(X509Certificate2 certificate, FileInfo certificateBundle)
+        {
+            ArgumentNullException.ThrowIfNull(certificate, nameof(certificate));
+            ArgumentNullException.ThrowIfNull(certificateBundle, nameof(certificateBundle));
+
+            X509Certificate2Collection certificates = new();
+
+            certificates.ImportFromPemFile(certificateBundle.FullName);
+
+            if (certificates.Contains(certificate))
+            {
+                certificates.Remove(certificate);
+
+                WriteCertificateBundle(certificates, certificateBundle);
+            }
+        }
+
+        private static void WriteCertificateBundle(X509Certificate2Collection certificates, FileInfo certificateBundle)
+        {
+            FileInfo file = new(Path.GetTempFileName());
+
+            try
+            {
+                using (StreamWriter writer = new(file.FullName))
+                {
+                    foreach (X509Certificate2 certificate in certificates)
+                    {
+                        char[] pem = PemEncoding.Write("CERTIFICATE", certificate.RawData);
+
+                        writer.WriteLine(pem);
+                        writer.WriteLine();
+                    }
+                }
+
+                BackupCertificateBundleIfNecessary(certificateBundle);
+
+                File.Copy(file.FullName, certificateBundle.FullName, overwrite: true);
+            }
+            finally
+            {
+                file.Delete();
+            }
+        }
+
+        private static void BackupCertificateBundleIfNecessary(FileInfo certificateBundle)
+        {
+            FileInfo backupCertificateBundle = new(Path.Combine(certificateBundle.DirectoryName!, $"{certificateBundle.Name}.backup"));
+
+            if (!backupCertificateBundle.Exists)
+            {
+                File.Copy(certificateBundle.FullName, backupCertificateBundle.FullName);
+            }
+        }
+    }
+}

--- a/TrustTestCert/Program.cs
+++ b/TrustTestCert/Program.cs
@@ -1,0 +1,305 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace TrustTestCert
+{
+    internal static class Program
+    {
+        private const int Success = 0;
+        private const int Error = 1;
+
+        private static int Main(string[] args)
+        {
+            try
+            {
+                return MainCore(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+
+                return Error;
+            }
+        }
+
+        private static int MainCore(string[] args)
+        {
+            if (args.Any(arg =>
+                string.Equals(arg, "-?", StringComparison.Ordinal)
+                    || string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase))
+                || args.Length < 3)
+            {
+                PrintHelp();
+
+                return Success;
+            }
+
+            string action = args[0].ToLowerInvariant();
+
+            switch (action)
+            {
+                case "add":
+                case "remove":
+                    break;
+
+                default:
+                    PrintHelp();
+
+                    return Error;
+            }
+
+            X509Certificate2? certificate = null;
+            DirectoryInfo? versionedSdkDirectory = null;
+
+            int argsCount = args.Length;
+
+            for (var i = 1; i < argsCount - 1; i += 2)
+            {
+                string arg = args[i].ToLowerInvariant();
+                string nextArg = args[i + 1];
+
+                switch (arg)
+                {
+                    case "-c":
+                    case "--certificate":
+                        certificate = new X509Certificate2(nextArg);
+                        break;
+
+                    case "-vsd":
+                    case "--versioned-sdk-directory":
+                        versionedSdkDirectory = new DirectoryInfo(nextArg);
+                        break;
+
+                    default:
+                        PrintHelp();
+
+                        return Error;
+                }
+            }
+
+            bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+            if (certificate is null ||
+                (isWindows != versionedSdkDirectory is null))
+            {
+                PrintHelp();
+
+                return Error;
+            }
+
+            FileInfo? certificateBundle = null;
+
+            if (versionedSdkDirectory is not null)
+            {
+                certificateBundle = new(Path.Combine(versionedSdkDirectory.FullName, "trustedroots", "codesignctl.pem"));
+
+                if (!certificateBundle.Exists)
+                {
+                    Console.Error.WriteLine($"The .NET SDK at {versionedSdkDirectory.FullName} does not have a fallback certificate bundle.");
+                    Console.Error.WriteLine($"Only .NET 6.0.400 SDK and later is supported.");
+
+                    return Error;
+                }
+            }
+
+            switch (action)
+            {
+                case "add":
+                    {
+                        if (isWindows)
+                        {
+                            return AddTrust(certificate);
+                        }
+                        else
+                        {
+                            return AddTrust(certificate, certificateBundle!);
+                        }
+                    }
+
+                case "remove":
+                    {
+                        if (isWindows)
+                        {
+                            return RemoveTrust(certificate);
+                        }
+                        else
+                        {
+                            return RemoveTrust(certificate, certificateBundle!);
+                        }
+                    }
+            }
+
+            return Error;
+        }
+
+        private static int AddTrust(X509Certificate2 certificate)
+        {
+            bool alreadyExists;
+
+            using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadWrite);
+
+                alreadyExists = store.Certificates.Contains(certificate);
+
+                if (!alreadyExists)
+                {
+                    store.Add(certificate);
+                }
+            }
+
+            if (alreadyExists)
+            {
+                Console.WriteLine("The certificate already exists in the current user's root store.");
+            }
+            else
+            {
+                using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+                {
+                    store.Open(OpenFlags.ReadOnly);
+
+                    if (store.Certificates.Contains(certificate))
+                    {
+                        Console.WriteLine("The certificate was added to the current user's root store.");
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("The certificate was not added to the current user's root store.");
+
+                        return Error;
+                    }
+                }
+            }
+
+            return Success;
+        }
+
+        private static int AddTrust(X509Certificate2 certificate, FileInfo certificateBundle)
+        {
+            bool alreadyExists = CertificateBundleUtilities.CertificateExistsInBundle(certificate, certificateBundle);
+
+            if (alreadyExists)
+            {
+                Console.WriteLine($"The certificate already exists in {certificateBundle.FullName}.");
+            }
+            else
+            {
+                CertificateBundleUtilities.AddCertificateToBundle(certificate, certificateBundle);
+
+                if (CertificateBundleUtilities.CertificateExistsInBundle(certificate, certificateBundle))
+                {
+                    Console.WriteLine($"The certificate was added to {certificateBundle.FullName}.");
+                }
+                else
+                {
+                    Console.Error.WriteLine($"The certificate was not added to {certificateBundle.FullName}.");
+
+                    return Error;
+                }
+            }
+
+            return Success;
+        }
+
+        private static int RemoveTrust(X509Certificate2 certificate)
+        {
+            bool alreadyExists;
+
+            using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadWrite);
+
+                alreadyExists = store.Certificates.Contains(certificate);
+
+                if (alreadyExists)
+                {
+                    store.Remove(certificate);
+                }
+            }
+
+            if (alreadyExists)
+            {
+                using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+                {
+                    store.Open(OpenFlags.ReadOnly);
+
+                    if (store.Certificates.Contains(certificate))
+                    {
+                        Console.Error.WriteLine("The certificate was not removed from the current user's root store.");
+
+                        return Error;
+                    }
+
+                    Console.WriteLine("The certificate was removed from the current user's root store.");
+                }
+            }
+            else
+            {
+                Console.WriteLine("The certificate was not present in the current user's root store.");
+            }
+
+            return Success;
+        }
+
+        private static int RemoveTrust(X509Certificate2 certificate, FileInfo certificateBundle)
+        {
+            bool alreadyExists = CertificateBundleUtilities.CertificateExistsInBundle(certificate, certificateBundle);
+
+            if (alreadyExists)
+            {
+                CertificateBundleUtilities.RemoveCertificateFromBundle(certificate, certificateBundle);
+
+                if (CertificateBundleUtilities.CertificateExistsInBundle(certificate, certificateBundle))
+                {
+                    Console.Error.WriteLine($"The certificate was not removed from {certificateBundle.FullName}.");
+
+                    return Error;
+                }
+
+                Console.WriteLine($"The certificate was removed from {certificateBundle.FullName}.");
+            }
+            else
+            {
+                Console.WriteLine($"The certificate was not present in {certificateBundle.FullName}.");
+            }
+
+            return Success;
+        }
+
+        private static void PrintHelp()
+        {
+            FileInfo file = new(Environment.ProcessPath!);
+            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file.Name);
+
+            Console.WriteLine($"Usage:  {file.Name} <add|remove> --certificate <CertificateFilePath> [option]");
+            Console.WriteLine();
+            Console.WriteLine("  Option                           Description");
+            Console.WriteLine("  -------------------------------- -------------------------------------------");
+            Console.WriteLine($"  --versioned-sdk-directory, -vsd  The versioned .NET SDK root directory that ");
+            Console.WriteLine($"                                   contains trustedroots{Path.DirectorySeparatorChar}codesignctl.pem.");
+            Console.WriteLine("                                   On Windows, this option is never used.");
+            Console.WriteLine("                                   On Linux/macOS, this option is required.");
+            Console.WriteLine("Examples:");
+            Console.WriteLine();
+            Console.WriteLine("  Windows:");
+            Console.WriteLine($"    {fileNameWithoutExtension}.exe add -c .\\test.cer");
+            Console.WriteLine($"      Adds the certificate to the current user's root store.");
+            Console.WriteLine();
+            Console.WriteLine($"    {fileNameWithoutExtension}.exe remove -c .\\test.cer");
+            Console.WriteLine($"      Removes the certificate from the current user's root store.");
+            Console.WriteLine();
+            Console.WriteLine("  Linux/macOS:");
+            Console.WriteLine($"    {fileNameWithoutExtension} add -c ./test.pem -vsd ~/dotnet/sdk/7.0.100");
+            Console.WriteLine($"      Adds the certificate to the specified .NET SDK's fallback certificate ");
+            Console.WriteLine("      bundle.");
+            Console.WriteLine();
+            Console.WriteLine($"    {fileNameWithoutExtension} remove -c ./test.pem -vsd ~/dotnet/sdk/7.0.100");
+            Console.WriteLine($"      Removes the certificate from the specified .NET SDK's fallback ");
+            Console.WriteLine("      certificate bundle.");
+            Console.WriteLine();
+        }
+    }
+}

--- a/TrustTestCert/TrustTestCert.csproj
+++ b/TrustTestCert/TrustTestCert.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <AssemblyName>MakeTestCert</AssemblyName>
+    <AssemblyName>TrustTestCert</AssemblyName>
     <TargetFramework>net6.0</TargetFramework>
     <Deterministic>true</Deterministic>
     <Features>strict</Features>

--- a/TrustTestCert/TrustTestCert.sln
+++ b/TrustTestCert/TrustTestCert.sln
@@ -1,0 +1,30 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.32721.557
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrustTestCert", "TrustTestCert.csproj", "{88E017EF-2E2F-42EC-8364-8F65634ED2D4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{07802C7B-1061-4547-89BB-36990FBBB7AB}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{88E017EF-2E2F-42EC-8364-8F65634ED2D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88E017EF-2E2F-42EC-8364-8F65634ED2D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88E017EF-2E2F-42EC-8364-8F65634ED2D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88E017EF-2E2F-42EC-8364-8F65634ED2D4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {37220895-3529-4F6C-ACD0-4581CA3BDD3A}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This is a super simple, cross-platform tool for trusting test code signing certificates in .NET 6.0.400 SDK and later.

This tool is intended to be used in conjunction with [MakeTestCert](https://github.com/NuGet/Entropy/pull/85).

`TrustTestCert -?` output:

```text
Usage:  TrustTestCert <add|remove> --certificate <CertificateFilePath> [option]

  Option                           Description
  -------------------------------- -------------------------------------------
  --versioned-sdk-directory, -vsd  The versioned .NET SDK root directory that 
                                   contains trustedroots/codesignctl.pem.
                                   On Windows, this option is never used.
                                   On Linux/macOS, this option is required.
Examples:

  Windows:
    TrustTestCert.exe add -c .\test.cer
      Adds the certificate to the current user's root store.

    TrustTestCert.exe remove -c .\test.cer
      Removes the certificate from the current user's root store.

  Linux/macOS:
    TrustTestCert add -c ./test.pem -vsd ~/dotnet/sdk/7.0.100
      Adds the certificate to the specified .NET SDK's fallback certificate 
      bundle.

    TrustTestCert remove -c ./test.pem -vsd ~/dotnet/sdk/7.0.100
      Removes the certificate from the specified .NET SDK's fallback 
      certificate bundle.
```

This PR also updates MakeTestCert as follows:
*  updates `MakeTestCert -?` to fit nicely in a default 80-character width Terminal 
*  adds license headers
*  downgrades the target framework from net7.0 to net6.0 because net6.0 is LTS