### PR TITLE
Add CI pipeline test failure analyzer

### DIFF
--- a/client-ci-analysis/ci-testfailure-analyzer/BuildFetcher.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/BuildFetcher.cs
@@ -1,0 +1,298 @@
+﻿using ci_testfailure_analyzer.Models.AzDO;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using File = System.IO.File;
+
+namespace ci_testfailure_analyzer
+{
+    internal class BuildFetcher
+    {
+        internal static async Task<List<BuildInfo>> DownloadBuildsAsync(DirectoryInfo cache, HttpClient httpClient, int buildDefinition)
+        {
+            BuildList result = await GetBuildsListAsync(cache, httpClient, buildDefinition);
+
+            // Azure DevOps can mark builds as retained, so they live much longer than the normal retention policy.
+            // We have very few builds retained older than 30 days, not enough to make estimates about build
+            // reliability during its week/sprint, so let's just ignore them.
+            var oldestBuild = DateTime.Today.AddDays(-30);
+            List<BuildInfo> builds = result.value
+                .Where(b => b.finishTime >= oldestBuild && b.status == "completed" && b.result != "succeeded") // Ignore builds still running
+                .OrderBy(b => b.finishTime)
+                .ToList();
+            return builds;
+        }
+
+        private static async Task<BuildList> GetBuildsListAsync(DirectoryInfo cache, HttpClient httpClient, int buildDefinition)
+        {
+            BuildList result;
+            var url = $"https://dev.azure.com/devdiv/devdiv/_apis/build/builds?definitions={buildDefinition}&api-version=5.1&result=!succeeded";
+
+            var buildsCacheFileInfo = new FileInfo(Path.Combine(cache.FullName, $"builds_{buildDefinition}.json"));
+            Stopwatch stopwatch = new Stopwatch();
+            if (!buildsCacheFileInfo.Exists || buildsCacheFileInfo.LastWriteTimeUtc >= DateTime.UtcNow.AddHours(-1))
+            {
+                stopwatch.Restart();
+                using (HttpResponseMessage response = await httpClient.GetAsync(url))
+                {
+                    if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                    {
+                        Console.WriteLine("Response: {0}", response);
+                        var content = await response.Content.ReadAsStringAsync();
+                        Console.WriteLine("Authentication token is expired, please renew!!!!!!!!!!!");
+                        Console.WriteLine(content);
+                        Environment.Exit(1);
+                    }
+                    using (Stream stream = await response.Content.ReadAsStreamAsync())
+                    {
+                        using (FileStream file = File.OpenWrite(buildsCacheFileInfo.FullName))
+                        {
+                            await stream.CopyToAsync(file);
+                        }
+                        stopwatch.Stop();
+                        Console.WriteLine("Got builds after {0}", stopwatch.Elapsed.TotalSeconds);
+                    }
+
+                }
+            }
+
+            using (var stream = File.OpenRead(buildsCacheFileInfo.FullName))
+            {
+                // Please note API end point returns only first 1000 builds, currently it's not exceeding 1000 so I didn't make it work more than 1000
+                result = await System.Text.Json.JsonSerializer.DeserializeAsync<BuildList>(stream);
+            }
+            Console.WriteLine("{0} builds in response", result.value.Count);
+
+            return result;
+        }
+
+        internal static async Task<List<CsvRow>> GetFailingFunctionalTestAsync(List<BuildInfo> builds, HttpClient httpClient)
+        {
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "api-version=5.0-preview.1;excludeUrls=true;enumsAsNumbers=true;msDateFormat=true;noArrayWrap=true");
+
+            List<TestFailure> testFailures = new();
+            for (int i = 0; i < builds.Count; i++)
+            {
+                BuildInfo buildInfo = builds[i];
+                string url = "https://devdiv.visualstudio.com/_apis/Contribution/HierarchyQuery/project/0bdbc590-a062-4c3f-b0f6-9383f67865ee";
+                string buildId = buildInfo.id.ToString();
+                // Encountered this issue: https://stackoverflow.com/q/10679214
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url);
+
+                string requestBody = "{\"contributionIds\":[\"ms.vss-test-web.test-tab-unifiedPipeline-summary-data-provider\"],\"dataProviderContext\":{\"properties\":{\"sourcePage\":{\"url\":\"https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=" + buildId + "&view=ms.vss-test-web.build-test-results-tab\",\"routeValues\":{\"project\":\"DevDiv\",\"viewname\":\"build-results\"}}}}}";
+
+                request.Content = new StringContent(requestBody,
+                                        Encoding.UTF8,
+                                        "application/json");
+
+                Console.WriteLine($"buildId : {buildId} {buildInfo.result}");
+
+                await httpClient.SendAsync(request)
+                  .ContinueWith(async responseTask =>
+                  {
+                      var res = responseTask.Result;
+
+                      if (res.StatusCode == System.Net.HttpStatusCode.OK)
+                      {
+                          var content = await res.Content.ReadAsStringAsync();
+                          TestFailure testFailure = JsonConvert.DeserializeObject<Models.AzDO.TestFailure>(content);
+
+                          if (testFailure?.dataProviders?.MsVssTestWebTestTabUnifiedPipelineSummaryDataProvider?.resultsAnalysis != null)
+                          {
+                              testFailures.Add(testFailure);
+                          }
+                          else
+                          {
+                              // This build doesn't have actual test error, most likely build error.
+                          }
+                      }
+                      else if (res.StatusCode == System.Net.HttpStatusCode.BadRequest)
+                      {
+                          Console.WriteLine("Response: {0}", res);
+                          var content = await res.Content.ReadAsStringAsync();
+
+                          Console.WriteLine("Unexpected error!!!!!!!!!!!");
+                          Console.WriteLine(content);
+                      }
+                      else if (res.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                      {
+                          Console.WriteLine("Response: {0}", res);
+                          var content = await res.Content.ReadAsStringAsync();
+                          Console.WriteLine("Authentication token is expired, please renew!!!!!!!!!!!");
+                          Console.WriteLine(content);
+                          Environment.Exit(1);
+                      }
+                      else
+                      {
+                          Console.WriteLine("Response: {0}", res);
+                          var content = await res.Content.ReadAsStringAsync();
+                          Console.WriteLine("Unexpected error!!!!!!!!!!!");
+                          Console.WriteLine(content);
+                      }
+                  });
+            }
+
+            List<(int testResultId, int testRunId)> failedTestIds = new();
+            for (int i = 0; i < testFailures.Count; i++)
+            {
+                failedTestIds.AddRange(testFailures[i].dataProviders.MsVssTestWebTestTabUnifiedPipelineSummaryDataProvider.resultsAnalysis.testFailuresAnalysis.newFailures.testResults.Select(x => (x.testResultId, x.testRunId)));
+                failedTestIds.AddRange(testFailures[i].dataProviders.MsVssTestWebTestTabUnifiedPipelineSummaryDataProvider.resultsAnalysis.testFailuresAnalysis.existingFailures.testResults.Select(x => (x.testResultId, x.testRunId)));
+            }
+
+            return await GetAllTestResultsAsync(failedTestIds, httpClient);
+        }
+
+        private static async Task<List<CsvRow>> GetAllTestResultsAsync(List<(int, int)> failedTestIds, HttpClient httpClient)
+        {
+            List<string> results = new();
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "application/json;api-version=5.2-preview.1;excludeUrls=true;enumsAsNumbers=true;msDateFormat=true;noArrayWrap=true");
+
+            List<string> tests = new();
+            foreach ((int testResultId, int testRunId) failedTest in failedTestIds)
+            {
+                string test = @"{
+                ""id"":" + failedTest.testResultId + @",
+                ""testRun"": {
+                        ""id"": """ + failedTest.testRunId + @"""
+                  }
+                }
+                ";
+
+                tests.Add(test);
+
+                // There is limit only 200 tests can be quered once.
+                if (tests.Count == 200)
+                {
+                    results.AddRange(await GetBatchedTestResultsAsync(tests, httpClient));
+
+                    tests.Clear();
+                }
+            }
+
+            if (tests.Count > 0)
+            {
+                results.AddRange(await GetBatchedTestResultsAsync(tests, httpClient));
+            }
+
+            return results.GroupBy(n => n)
+                            .Select(c => new CsvRow { TestName = c.Key, Count = c.Count() }).OrderByDescending(r => r.Count).ToList();
+        }
+
+        private static async Task<List<string>> GetBatchedTestResultsAsync(List<string> tests, HttpClient httpClient)
+        {
+            List<string> results = new();
+            string testResultsUrl = "https://devdiv.vstmr.visualstudio.com/DevDiv/_apis/testresults/results";
+
+            // Encountered this issue: https://stackoverflow.com/q/10679214
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, testResultsUrl);
+
+            string requestBody = @"{
+    ""results"": ["
++ string.Join(",", tests) +
+@"],
+    ""fields"": [
+        ""Outcome"",
+        ""TestCaseTitle"",
+        ""AutomatedTestName"",
+        ""AutomatedTestStorage"",
+        ""TestResultGroupType"",
+        ""Duration"",
+        ""ReleaseEnvId"",
+        ""Owner"",
+        ""FailingSince"",
+        ""DateStarted"",
+        ""DateCompleted"",
+        ""OutcomeConfidence"",
+        ""IsTestResultFlaky"",
+        ""TestResultFlakyState""
+    ]
+}";
+
+            request.Content = new StringContent(requestBody,
+                                    Encoding.UTF8,
+                                    "application/json");
+
+            try
+            {
+                await httpClient.SendAsync(request)
+                  .ContinueWith(async responseTask =>
+                  {
+                      var res = responseTask.Result;
+
+                      if (res.StatusCode == System.Net.HttpStatusCode.OK)
+                      {
+                          var content = await res.Content.ReadAsStringAsync();
+                          TestResults testResults = JsonConvert.DeserializeObject<Models.AzDO.TestResults>(content);
+
+                          List<string> allFailedTests = testResults.Results.Select(t => t.TestCaseTitle).ToList();
+
+                          results.AddRange(allFailedTests);
+                      }
+                  });
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return results;
+        }
+
+
+        internal static void WriteCVSFile(List<CsvRow> rows, DirectoryInfo cache, int buildDefinition)
+        {
+            string cvsFile = string.Format("failedTestsReport-{0}-{1:yyyy-MM-dd_hh-mm}.csv",
+            buildDefinition,
+            DateTime.Now);
+            cvsFile = Path.Join(cache.FullName, cvsFile);
+
+            using (StreamWriter file = new StreamWriter(cvsFile))
+            {
+                file.WriteLine("TestFullName, FailureCount");
+                for (int i = 0; i < rows.Count; i++)
+                {
+                    CsvRow row = rows[i];
+                    file.WriteLine(StringToCSVCell(row.TestName) + ',' + '"' + row.Count + '"');
+                }
+
+                file.WriteLine($"Total test count, {rows.Count}");
+                file.WriteLine();
+                file.WriteLine($"Failed tests with frequency count from {DateTime.Now.AddDays(-30)} to {DateTime.Now}");
+
+            }
+
+            Console.WriteLine($"Failed test report is written to {cvsFile}");
+        }
+
+        /// <summary>
+        /// Turn a string into a CSV cell output
+        /// </summary>
+        /// <param name="str">String to output</param>
+        /// <returns>The CSV cell formatted string</returns>
+        public static string StringToCSVCell(string str)
+        {
+            bool mustQuote = (str.Contains(",") || str.Contains("\"") || str.Contains("\r") || str.Contains("\n"));
+            if (mustQuote)
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("\"");
+                foreach (char nextChar in str)
+                {
+                    sb.Append(nextChar);
+                    if (nextChar == '"')
+                        sb.Append("\"");
+                }
+                sb.Append("\"");
+                return sb.ToString();
+            }
+
+            return str;
+        }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/BuildInfo.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/BuildInfo.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace ci_testfailure_analyzer.Models.AzDO
+{
+    [DebuggerDisplay("{buildNumber} ({id})")]
+    internal class BuildInfo
+    {
+        public Definition definition { get; set; }
+        public uint id { get; set; }
+        public string buildNumber { get; set; }
+        public string status { get; set; }
+        public string result { get; set; }
+        public DateTime queueTime { get; set; }
+        public DateTime startTime { get; set; }
+        public DateTime finishTime { get; set; }
+
+        [JsonPropertyName("_links")]
+        public Dictionary<string, Link> links { get; set; }
+
+        public string url { get; set; }
+
+        public List<BuildInfoValidationResult> validationResults { get; set; }
+
+        public string sourceBranch { get; set; }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/BuildInfoValidationResult.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/BuildInfoValidationResult.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics;
+
+namespace ci_testfailure_analyzer.Models.AzDO
+{
+    [DebuggerDisplay("{result}: {message}")]
+    internal class BuildInfoValidationResult
+    {
+        public string result { get; set; }
+        public string message { get; set; }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/BuildList.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/BuildList.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ci_testfailure_analyzer.Models.AzDO
+{
+    [DebuggerDisplay("({count})")]
+    internal class BuildList
+    {
+        public uint count { get; set; }
+        public List<BuildInfo> value { get; set; }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/Csv.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/Csv.cs
@@ -1,0 +1,8 @@
+﻿namespace ci_testfailure_analyzer.Models.AzDO
+{
+    internal class CsvRow
+    {
+        public string TestName { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/Definition.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/Definition.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics;
+
+namespace ci_testfailure_analyzer.Models.AzDO
+{
+    [DebuggerDisplay("{name} ({id})")]
+    internal class Definition
+    {
+        public uint id { get; set; }
+        public string name { get; set; }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/Link.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/Link.cs
@@ -1,0 +1,10 @@
+﻿using System.Diagnostics;
+
+namespace ci_testfailure_analyzer.Models.AzDO
+{
+    [DebuggerDisplay("{href}")]
+    public class Link
+    {
+        public string href { get; set; }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/TestFailure.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/TestFailure.cs
@@ -1,0 +1,135 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace ci_testfailure_analyzer.Models.AzDO
+{
+    public class TestFailure
+    {
+        public DataProviders dataProviders { get; set; }
+    }
+
+    public class _2
+    {
+        public int outcome { get; set; }
+        public int count { get; set; }
+        public string duration { get; set; }
+    }
+
+    public class _3
+    {
+        public int totalTestCount { get; set; }
+        public int notReportedTestCount { get; set; }
+        public string duration { get; set; }
+        public AggregatedResultDetailsByOutcome aggregatedResultDetailsByOutcome { get; set; }
+        public int outcome { get; set; }
+        public int count { get; set; }
+    }
+
+    public class AggregatedResultDetailsByOutcome
+    {
+        public _2 _2 { get; set; }
+        public _3 _3 { get; set; }
+    }
+
+    public class CurrentContext
+    {
+        public int pipelineId { get; set; }
+    }
+
+    public class DataProviders
+    {
+        [JsonProperty("ms.vss-test-web.test-tab-unifiedPipeline-summary-data-provider")]
+        public MsVssTestWebTestTabUnifiedPipelineSummaryDataProvider MsVssTestWebTestTabUnifiedPipelineSummaryDataProvider { get; set; }
+    }
+
+
+    public class ExistingFailures
+    {
+        public int count { get; set; }
+        public List<TestResult> testResults { get; set; }
+    }
+
+    public class FixedTests
+    {
+        public int count { get; set; }
+        public List<object> testResults { get; set; }
+    }
+
+    public class MsVssTestWebTestTabUnifiedPipelineSummaryDataProvider
+    {
+        public CurrentContext currentContext { get; set; }
+        public ResultSummary resultSummary { get; set; }
+        public ResultsAnalysis resultsAnalysis { get; set; }
+        public RunSummary runSummary { get; set; }
+    }
+
+    public class NewFailures
+    {
+        public int count { get; set; }
+        public List<TestResult> testResults { get; set; }
+    }
+
+    public class PreviousContext
+    {
+        public int pipelineId { get; set; }
+    }
+
+    public class ResultsAnalysis
+    {
+        public PreviousContext previousContext { get; set; }
+        public TestFailuresAnalysis testFailuresAnalysis { get; set; }
+        public ResultsDifference resultsDifference { get; set; }
+    }
+
+    public class ResultsDifference
+    {
+        public int increaseInTotalTests { get; set; }
+        public int increaseInFailures { get; set; }
+        public int increaseInPassedTests { get; set; }
+        public int increaseInNonImpactedTests { get; set; }
+        public int increaseInOtherTests { get; set; }
+        public string increaseInDuration { get; set; }
+    }
+
+    public class ResultSummary
+    {
+        public ResultSummaryByRunState resultSummaryByRunState { get; set; }
+    }
+
+    public class ResultSummaryByRunState
+    {
+        public _3 _3 { get; set; }
+    }
+
+    public class RunSummary
+    {
+        public int totalRunsCount { get; set; }
+        public string duration { get; set; }
+        public RunSummaryByState runSummaryByState { get; set; }
+        public RunSummaryByOutcome runSummaryByOutcome { get; set; }
+    }
+
+    public class RunSummaryByOutcome
+    {
+        public int _0 { get; set; }
+        public int _1 { get; set; }
+    }
+
+    public class RunSummaryByState
+    {
+        public int _3 { get; set; }
+    }
+
+    public class TestFailuresAnalysis
+    {
+        public NewFailures newFailures { get; set; }
+        public ExistingFailures existingFailures { get; set; }
+        public FixedTests fixedTests { get; set; }
+    }
+
+    public class TestResult
+    {
+        public int testResultId { get; set; }
+        public int testRunId { get; set; }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/TestResults.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/AzDO/TestResults.cs
@@ -1,0 +1,90 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace ci_testfailure_analyzer.Models.AzDO
+{
+    public class TestResults
+    {
+        [JsonProperty("results")]
+        public List<Result> Results { get; set; }
+        [JsonProperty("fields")]
+        public List<string> Fields { get; set; }
+    }
+    public class Result
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        [JsonProperty("project")]
+        public Project Project { get; set; }
+        [JsonProperty("startedDate")]
+        public DateTime StartedDate { get; set; }
+        [JsonProperty("completedDate")]
+        public DateTime CompletedDate { get; set; }
+        [JsonProperty("outcome")]
+        public string Outcome { get; set; }
+        [JsonProperty("testCase")]
+        public TestCase TestCase { get; set; }
+        [JsonProperty("testPoint")]
+        public TestPoint TestPoint { get; set; }
+        [JsonProperty("testRun")]
+        public TestRun TestRun { get; set; }
+        [JsonProperty("priority")]
+        public int Priority { get; set; }
+        [JsonProperty("failureType")]
+        public string FailureType { get; set; }
+        [JsonProperty("automatedTestStorage")]
+        public string AutomatedTestStorage { get; set; }
+        [JsonProperty("testCaseTitle")]
+        public string TestCaseTitle { get; set; }
+        [JsonProperty("customFields")]
+        public List<object> CustomFields { get; set; }
+        [JsonProperty("failingSince")]
+        public FailingSince FailingSince { get; set; }
+        [JsonProperty("testCaseReferenceId")]
+        public int TestCaseReferenceId { get; set; }
+        [JsonProperty("automatedTestName")]
+        public string AutomatedTestName { get; set; }
+    }
+    public class Project
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+    public class TestCase
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+    public class TestPoint
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+    public class TestRun
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+    public class FailingSince
+    {
+        [JsonProperty("date")]
+        public DateTime Date { get; set; }
+        [JsonProperty("build")]
+        public Build Build { get; set; }
+    }
+    public class Build
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        [JsonProperty("definitionId")]
+        public int DefinitionId { get; set; }
+        [JsonProperty("number")]
+        public string Number { get; set; }
+        [JsonProperty("buildSystem")]
+        public string BuildSystem { get; set; }
+    }
+
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/ClientCiAnalysis/Week.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/ClientCiAnalysis/Week.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace ci_testfailure_analyzer.Models.ClientCiAnalysis
+{
+    internal record Week(string sprint, char week)
+    {
+        public static Week FromDate(DateTime when)
+        {
+            var monday = when.AddDays(-(when.DayOfWeek - DayOfWeek.Monday)).Date;
+            var startOfSprint = monday.AddDays(-7 * (monday.Day / 7));
+            var sprint = $"{startOfSprint.Year:d4}-{startOfSprint.Month:d2}";
+            char week = (char)('A' + (when - startOfSprint).Days / 7);
+
+            return new Week(sprint, week);
+        }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Models/ClientCiAnalysis/WeekBuilds.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Models/ClientCiAnalysis/WeekBuilds.cs
@@ -1,0 +1,12 @@
+﻿using ci_testfailure_analyzer.Models.AzDO;
+using System.Collections.Generic;
+
+namespace ci_testfailure_analyzer.Models.ClientCiAnalysis
+{
+    internal class WeekBuilds
+    {
+        public List<BuildInfo> Official { get; } = new List<BuildInfo>();
+        public List<BuildInfo> PullRequest { get; } = new List<BuildInfo>();
+
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/Program.cs
+++ b/client-ci-analysis/ci-testfailure-analyzer/Program.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using ci_testfailure_analyzer.Models.AzDO;
+using System.Linq;
+
+namespace ci_testfailure_analyzer
+{
+    internal class Program
+    {
+        static async Task Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Expected at least 1 argument, got " + args.Length);
+                return;
+            }
+
+            if (File.Exists(args[0]))
+            {
+                Console.WriteLine("Expected '{0}' to be a directory, but found a file", args[0]);
+                return;
+            }
+
+            var cache = new DirectoryInfo(args[0]);
+            if (!cache.Exists)
+            {
+                cache.Create();
+            }
+
+            var buildDefinition = 8118; //private build. Use 8117 for official, 14219 for trusted build.
+
+            if (args.Length > 1 && int.TryParse(args[1], out buildDefinition))
+            { }
+
+            Console.WriteLine($"Cache path: {cache.FullName}");
+            Console.WriteLine($"CI pipeline Build Definition: {buildDefinition}");
+
+            var accountName = Environment.GetEnvironmentVariable("AzDO_ACCOUNT");
+
+            // You can get bearer token from web browser use here, had no time to fix automatically getting it.
+            var bearerToken = Environment.GetEnvironmentVariable("AzDO_BEARERTOKEN");
+            if (string.IsNullOrEmpty(bearerToken))
+            {
+                try
+                {
+                    // Bearer token expire after few minutes so save in easy to update txt file.
+                    string filename = Path.Combine(cache.FullName, "bearerToken.txt");
+                    Console.WriteLine($"Reading bearer token from {filename}");
+                    string[] lines = File.ReadLines(filename).ToArray();
+
+                    bearerToken = lines[0];
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                    throw;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(accountName) || string.IsNullOrWhiteSpace(bearerToken))
+            {
+                Console.WriteLine("Set AzDO_ACCOUNT and AzDO_BEARERTOKEN (or update bearerToken.txt) environment variables.");
+                Console.WriteLine("Project properties -> Debug in VS");
+                Console.WriteLine("launchSettings.json in VSCode");
+                return;
+            }
+
+            var httpClient = CreateAzureDevOpsClient(accountName, bearerToken);
+
+            List<BuildInfo> builds = await BuildFetcher.DownloadBuildsAsync(cache, httpClient, buildDefinition);
+            List<CsvRow> rows = await BuildFetcher.GetFailingFunctionalTestAsync(builds, httpClient);
+            BuildFetcher.WriteCVSFile(rows, cache, buildDefinition);
+
+            Console.WriteLine("-----End-----");
+        }
+
+        private static HttpClient CreateAzureDevOpsClient(string accountName, string bearerToken)
+        {
+            var httpClient = new HttpClient();
+
+            var cred = new AuthenticationHeaderValue("BASIC", Convert.ToBase64String(Encoding.ASCII.GetBytes(accountName + ":" + bearerToken)));
+            httpClient.DefaultRequestHeaders.Authorization = cred;
+
+            var userAgent = new ProductInfoHeaderValue("NugetClientCiAnalysis", "0.1");
+            httpClient.DefaultRequestHeaders.UserAgent.Add(userAgent);
+
+            return httpClient;
+        }
+    }
+}

--- a/client-ci-analysis/ci-testfailure-analyzer/ci-testfailure-analyzer.csproj
+++ b/client-ci-analysis/ci-testfailure-analyzer/ci-testfailure-analyzer.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>ci_testfailure_analyzer</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/client-ci-analysis/ci-testfailure-analyzer/readme.md
+++ b/client-ci-analysis/ci-testfailure-analyzer/readme.md
@@ -1,0 +1,7 @@
+﻿# ci-testfailure-analyzer
+
+Steps to use:
+
+1. Go to AzDo, view build, view and download build logs for run test phase
+2. Run this app, passing log directory path.
+  * It'll make AzDo api calls to discover failed test within last 30 days and summarize failed test data.

--- a/client-ci-analysis/ci-testfailure-analyzer/readme.md
+++ b/client-ci-analysis/ci-testfailure-analyzer/readme.md
@@ -1,7 +1,24 @@
 ﻿# ci-testfailure-analyzer
 
-Steps to use:
+Tools to help analyze CI builds for failed/flaky tests, it generates cvs report into output directory specified in parameter.
 
-1. Go to AzDo, view build, view and download build logs for run test phase
-2. Run this app, passing log directory path.
-  * It'll make AzDo api calls to discover failed test within last 30 days and summarize failed test data.
+## Setup following env vars for authentication
+
+1. "AzDO_ACCOUNT" : your MS user id.
+1. "AzDO_BEARERTOKEN": Bearer token. Since bearer token(oauth2) expire often you can instead set in `bearerToken.txt` file (located in output directory) and refresh it when it expires. Please note don't include `Bearer` part of bearer authorization token.
+
+## Synopsis
+
+```dotnetcli
+ci-testfailure-analyzer.exe <OUTPUT_DIRECTORY_PATH> <CI_PIPELINE_ID>
+```
+
+## Arguments
+
+- **`OUTPUT_DIRECTORY_PATH`**
+
+  Path to the cvs report generated to. Also
+
+- **`CI_PIPELINE_ID`**
+
+  Integer id number of the CI pipeline you wish to analyze.

--- a/client-ci-analysis/client-ci-analysis.sln
+++ b/client-ci-analysis/client-ci-analysis.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30128.36
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32728.150
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "find-buids-in-sprint", "find-buids-in-sprint\find-buids-in-sprint.csproj", "{77967AEE-1BE6-4424-AB78-27484B0FF578}"
 EndProject
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ci-failure-analysis", "ci-f
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "find-incomplete-tests", "find-incomplete-tests\find-incomplete-tests.csproj", "{107574C5-102F-4511-A56B-F47B4B82A3C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkManager", "NetworkManager\NetworkManager.csproj", "{E9934781-5FE8-4F16-8318-9DADE60C39F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetworkManager", "NetworkManager\NetworkManager.csproj", "{E9934781-5FE8-4F16-8318-9DADE60C39F0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ci-testfailure-analyzer", "ci-testfailure-analyzer\ci-testfailure-analyzer.csproj", "{C6075BFA-8D13-4DE2-BDED-FA927429E473}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{E9934781-5FE8-4F16-8318-9DADE60C39F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9934781-5FE8-4F16-8318-9DADE60C39F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9934781-5FE8-4F16-8318-9DADE60C39F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6075BFA-8D13-4DE2-BDED-FA927429E473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6075BFA-8D13-4DE2-BDED-FA927429E473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6075BFA-8D13-4DE2-BDED-FA927429E473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6075BFA-8D13-4DE2-BDED-FA927429E473}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/1535

Find all failed CI pipeline builds from last 30 days then search for failed tests then write to cvs file. 1st parameter is work directory to write output data and read bearer token and 2nd parameter for pipeline id.
Here use `8118` for `private`, `8117` for `official` pipeline, `14219` for `trusted` pipeline for 2nd parameter.
![image](https://user-images.githubusercontent.com/8766776/184260162-00d0371f-0eff-48c7-b822-8a4dfa9ddb76.png)

Generated file screenshot, it'll descending order failed tests by failure count.
![image](https://user-images.githubusercontent.com/8766776/184260374-aaab4575-8814-4296-b198-65b51505200d.png)

We can verify if tests are really tests flaky or not by looking at failure count and if it's already in `dev` branch.

Please note: You need to setup env vars for authentication, see `ci-testfailure-analyzer/readme.md` file for more details.

@NuGet/nuget-client 