### PR TITLE
Improve the release notes generator

### DIFF
--- a/ReleaseNotesGenerator/README.md
+++ b/ReleaseNotesGenerator/README.md
@@ -1,5 +1,8 @@
 # Release Notes Generator tool
 
 - Go to ReleaseNotesGenerator project directory
-- dotnet run NuGet/Home <MajorVersion.MinorVersion>
-- After running the command, there should be an md file in the directory.
+- If the release branch has any commits that are not going to be in the release run the following:
+  - dotnet run <MajorVersion.MinorVersion> --start-commit startCommitSha
+- If the release branch does not have any commits that are going to be in the release run the following:
+  - dotnet run <MajorVersion.MinorVersion> --start-commit startCommitSha --end-commit
+- After running the command, there should be an md file in the directory

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator/IssueLabels.cs
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator/IssueLabels.cs
@@ -12,6 +12,6 @@
         public static string Spec = "Type:Spec";
         public static string Test = "Type:Test";
         public static string Docs = "Type:Docs";
-
+        public static string Community = "Community";
     }
 }

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator/Options.cs
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator/Options.cs
@@ -6,21 +6,17 @@ namespace ReleaseNotesGenerator
 {
     class Options
     {
-        [Value(0, Required = true, HelpText = "Repository to get the issues from.")]
-        public string Repo { get; set; }
-
-        [Value(1, Required = true, HelpText = "Release version to generate the release notes for.")]
+        [Value(0, Required = true, HelpText = "Release version to generate the release notes for.")]
         public string Release { get; set; }
 
         [Option('g', "github-token", Required = false, HelpText = "GitHub Token for Auth. If not specified, it will acquired automatically.")]
         public string GitHubToken { get; set; }
 
-        [Option("start-commit", Required = false, HelpText = "The starting sha for the current release. This commit *must* be on the release branch.")]
+        [Option("start-commit", Required = true, HelpText = "The starting sha for the current release. This commit must be on the release branch.")]
         public string StartSha { get; set; }
 
-        [Option("end-commit", Required = false, HelpText = "The starting sha for the current release. This commit *must* be on the release branch. ")]
+        [Option("end-commit", Required = false, HelpText = "The starting sha for the current release. This commit must be on the release branch. If not specified, the tip of the release branch will be used.")]
         public string EndSha { get; set; }
-
 
         [Usage(ApplicationAlias = "release-notes-generator")]
         public static IEnumerable<Example> Examples
@@ -29,7 +25,7 @@ namespace ReleaseNotesGenerator
             {
                 return new List<Example>()
                 {
-                    new Example("Generate release notes for a particular release", new Options { Repo = "NuGet/Home", Release = "6.3", GitHubToken = "asdf" })
+                    new Example("Generate release notes for a particular release", new Options { Release = "6.3", GitHubToken = "asdf", StartSha =" startSha", EndSha = "endSha" })
                 };
             }
         }

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator/Options.cs
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator/Options.cs
@@ -15,6 +15,13 @@ namespace ReleaseNotesGenerator
         [Option('g', "github-token", Required = false, HelpText = "GitHub Token for Auth. If not specified, it will acquired automatically.")]
         public string GitHubToken { get; set; }
 
+        [Option("start-commit", Required = false, HelpText = "The starting sha for the current release. This commit *must* be on the release branch.")]
+        public string StartSha { get; set; }
+
+        [Option("end-commit", Required = false, HelpText = "The starting sha for the current release. This commit *must* be on the release branch. ")]
+        public string EndSha { get; set; }
+
+
         [Usage(ApplicationAlias = "release-notes-generator")]
         public static IEnumerable<Example> Examples
         {

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator/ReleaseNotesGenerator.cs
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator/ReleaseNotesGenerator.cs
@@ -298,7 +298,7 @@ namespace ReleaseNotesGenerator
             {
                 return VSYear.ToString();
             }
-            return "<TODO: VSYear. Consider updating the tool.>";
+            return "<TODO: VSYear. Unknown version/year combo, consider updating the tool.>";
         }
 
         private static void OutputCommunityPullRequestsSection(

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator/ReleaseNotesGenerator.cs
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator/ReleaseNotesGenerator.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace ReleaseNotesGenerator
@@ -40,7 +41,13 @@ namespace ReleaseNotesGenerator
         public async Task<string> GenerateChangelog()
         {
             Dictionary<IssueType, List<Issue>> issues = await GetIssuesByType(Options.Release);
-            return GenerateMarkdown(Options.Release, issues);
+
+            List<PullRequest> CommunityPullRequests = null;
+            if (!string.IsNullOrEmpty(Options.StartSha))
+            {
+                CommunityPullRequests = await GetCommunityPullRequests(GitHubClient, Options.StartSha, $"release-{Options.Release}.x");
+            }
+            return GenerateMarkdown(Options.Release, issues, CommunityPullRequests);
         }
 
         public static async Task<IList<Issue>> GetIssuesForMilestone(GitHubClient client, string org, string repo, Milestone milestone)
@@ -57,11 +64,63 @@ namespace ReleaseNotesGenerator
             return issuesForMilestone.ToList();
         }
 
+        public static async Task<List<PullRequest>> GetCommunityPullRequests(GitHubClient gitHubClient, string startSha, string branchName, string endSha = null)
+        {
+            var orgName = "nuget";
+            var repoName = "nuget.client";
+            Console.Write($"Processing the pull requests for {branchName}, ");
+
+            var githubBranch = await gitHubClient.Repository.Branch.Get(orgName, repoName, branchName);
+            string finalSha = string.IsNullOrEmpty(endSha) ? githubBranch.Commit.Sha : endSha;
+
+            Console.WriteLine($"starting with {startSha} and ending with {finalSha}");
+
+            var commits = (await gitHubClient.Repository.Commit.Compare(orgName, repoName, startSha, finalSha)).Commits;
+
+            List<PullRequest> pullRequests = new();
+
+            foreach (var commit in commits)
+            {
+                var assumedId = GetPRId(commit.Commit.Message);
+                try
+                {
+                    var pullRequest = await gitHubClient.Repository.PullRequest.Get(orgName, repoName, assumedId);
+                    var isCommunity = pullRequest.Labels.Any(e => e.Name == IssueLabels.Community);
+                    if (isCommunity)
+                    {
+                        pullRequests.Add(pullRequest);
+                    }
+                }
+                catch
+                {
+                    Console.WriteLine($"Failed retrieving the pull request for {commit.HtmlUrl}. Calculate PR Id: {assumedId}");
+                }
+            }
+
+            return pullRequests;
+
+            static int GetPRId(string message)
+            {
+                //use RegexOptions.RightToLeft to match from the right side, to ignore the other numbers in the title
+                //E.g. 	Fix spelling of Wiederherstellen (NuGet/Home#11774) (#4591)
+                //Or, Revert "Disable timing out EndToEnd tests (#4592)" (#4597) Fixes https://github.com/NuGet/Client.Engineering/issues/1572 This reverts commit acee7c1c1773e3d96ca806b10ba068dd09b0baf5.
+                foreach (Match match in new Regex(@"\(#\d+\)", RegexOptions.RightToLeft).Matches(message))
+                {
+                    // match={(#4634)}, pullRequestsIdText=4634
+                    var pullRequestIdText = match.Value.Substring(2, match.Length - 3);
+                    int.TryParse(pullRequestIdText, out int prId);
+                    return prId;
+                }
+
+                return -1;
+            }
+        }
+
         private async Task<Dictionary<IssueType, List<Issue>>> GetIssuesByType(string releaseId)
         {
             var issuesByType = new Dictionary<IssueType, List<Issue>>();
 
-            GetRepositoryDetrails(out string org, out string repo);
+            GetRepositoryDetails(out string org, out string repo);
 
             Milestone relevantMilestone = await FindMatchingMilestone(releaseId, org, repo);
 
@@ -159,12 +218,12 @@ namespace ReleaseNotesGenerator
             return issuesByType;
         }
 
-        private void GetRepositoryDetrails(out string org, out string repo)
+        private void GetRepositoryDetails(out string org, out string repo)
         {
             var repoParts = Options.Repo.Split("/");
             if (repoParts.Length != 2)
             {
-                throw new Exception($"Expected the repo to be 2 part, separated by `/`. Repo:{Options.Repo }, parts{string.Join("; ", repoParts)} ");
+                throw new Exception($"Expected the repo to be 2 part, separated by `/`. Repo:{Options.Repo}, parts{string.Join("; ", repoParts)} ");
             }
             org = repoParts[0];
             repo = repoParts[1];
@@ -183,14 +242,14 @@ namespace ReleaseNotesGenerator
             return relevantMilestone;
         }
 
-        private string GenerateMarkdown(string releaseId, Dictionary<IssueType, List<Issue>> labelSet)
+        private string GenerateMarkdown(string releaseId, Dictionary<IssueType, List<Issue>> labelSet, List<PullRequest> communityPullRequests)
         {
             StringBuilder builder = new StringBuilder();
             builder.AppendLine("---");
             builder.AppendLine(string.Format("title: NuGet {0} Release Notes", Options.Release));
             builder.AppendLine(string.Format("description: Release notes for NuGet {0} including new features, bug fixes, and DCRs.", Options.Release));
-            builder.AppendLine("author: <GithubAlias>");
-            builder.AppendLine("ms.author: <MicrosoftAlias>");
+            builder.AppendLine("author: <TODO: GithubAlias>");
+            builder.AppendLine("ms.author: <TODO: MicrosoftAlias>");
             builder.AppendLine(string.Format("ms.date: {0}", DateTime.Now.ToString("d", System.Globalization.CultureInfo.GetCultureInfo("en-US"))));
             builder.AppendLine("ms.topic: conceptual");
             builder.AppendLine("---");
@@ -201,9 +260,9 @@ namespace ReleaseNotesGenerator
             builder.AppendLine();
             builder.AppendLine("| NuGet version | Available in Visual Studio version | Available in .NET SDK(s) |");
             builder.AppendLine("|:---|:---|:---|");
-            builder.AppendLine("| [**<NuGetVersion>**](https://nuget.org/downloads) | [Visual Studio <VSYear> version <VSVersion>](https://visualstudio.microsoft.com/downloads/) | [<SDKVersion>](https://dotnet.microsoft.com/download/dotnet-core/<SDKMajorMinorVersionOnly>)<sup>1</sup> |");
+            builder.AppendLine(string.Format("| [**{0}**](https://nuget.org/downloads) | [Visual Studio <TODO: VSYear> version <TODO: VSVersion>](https://visualstudio.microsoft.com/downloads/) | [<TODO: SDKVersion>](https://dotnet.microsoft.com/download/dotnet-core/<SDKMajorMinorVersionOnly>)<sup>1</sup> |", Options.Release));
             builder.AppendLine();
-            builder.AppendLine("<sup>1</sup> Installed with Visual Studio <VSYear> with.NET Core workload");
+            builder.AppendLine("<sup>1</sup> Installed with Visual Studio <TODO: VSYear> with.NET Core workload");
             builder.AppendLine();
             builder.AppendLine(string.Format("## Summary: What's New in {0}", Options.Release));
             builder.AppendLine();
@@ -212,17 +271,56 @@ namespace ReleaseNotesGenerator
             builder.AppendLine();
             OutputSection(labelSet, builder, IssueType.DCR);
             OutputSection(labelSet, builder, IssueType.Bug);
+            builder.AppendLine("[List of commits in this release](TODO: Provide the link.)");
+            builder.AppendLine();
+            OutputCommunityPullRequestsSection(communityPullRequests, builder);
 
             foreach (var key in labelSet.Keys)
             {
                 if (key != IssueType.Feature && key != IssueType.DCR && key != IssueType.Bug)
                 {
-                    // these sections shouldn't exist. tweak the issues in github until these issues move to Feature, Bug, DCR, or go away.
                     OutputSection(labelSet, builder, key, problem: true);
                 }
             }
 
             return builder.ToString();
+        }
+
+        private static void OutputCommunityPullRequestsSection(
+            List<PullRequest> communityPullRequests,
+            StringBuilder builder)
+        {
+            if (communityPullRequests != null)
+            {
+                if (communityPullRequests.Count > 0)
+                {
+                    AddCommunityContributionsHeader(builder);
+                    builder.AppendLine("Thank you to all the contributors who helped make this NuGet release awesome!");
+                    builder.AppendLine();
+
+                    var contributors = communityPullRequests.GroupBy(e => e.User).OrderBy(e => e.Count());
+                    foreach (var contribution in contributors)
+                    {
+                        builder.AppendLine($"* [{contribution.Key.Login}]({contribution.Key.HtmlUrl})");
+                        foreach (var PR in contribution)
+                        {
+                            builder.AppendLine($"  * [{PR.Number}]({PR.HtmlUrl}) {PR.Title}");
+                        }
+                    }
+                }
+            }
+            else
+            {
+                AddCommunityContributionsHeader(builder);
+                builder.AppendLine("TODO: The automatic generation of the release notes did not try to generate the community contributions. " +
+                    "Either rerun the tool with the community contributions option or add the contributors manually. You may delete this section if there were not community contributions.");
+            }
+
+            static void AddCommunityContributionsHeader(StringBuilder builder)
+            {
+                builder.AppendLine("### Community contributions");
+                builder.AppendLine();
+            }
         }
 
         private static void OutputSection(
@@ -232,20 +330,16 @@ namespace ReleaseNotesGenerator
             bool includeHeader = true,
             bool problem = false)
         {
-
-            List<Issue> issues = null;
-            bool hasIssues = labelSet.TryGetValue(key, out issues);
-
-            if (hasIssues)
+            if (labelSet.TryGetValue(key, out List<Issue> issues))
             {
                 if (includeHeader)
                 {
-                    var issueTypeString = key.ToString();
+                    var issueTypeString = (problem ? "TODO: Issues that could not be categorized. Make sure the issue has the correct milestone (if required) or an appropriate Type label - " : string.Empty) + key.ToString();
                     builder.AppendLine(string.Format("**{0}s:**", issueTypeString));
                     builder.AppendLine();
                 }
 
-                foreach (var issue in labelSet[key])
+                foreach (var issue in issues)
                 {
                     builder.AppendLine("* " + issue.Title + " - " + "[#" + issue.Number + "](" + issue.HtmlUrl + ")");
                     builder.AppendLine();


### PR DESCRIPTION
Fixes https://github.com/NuGet/Client.Engineering/issues/324
Fixes https://github.com/NuGet/Client.Engineering/issues/1953

- This PR adds the ability to harvest community contributions automatically. To achieve that we need to provide the start commit. We can start inferring that commit from the tags if we wish. That change would be really simple, but I decided not to make too many changes for now.
- Remove some unnecessary options. We've made parts of this tool generic in the past, but let's be real, it's super tailored to our repo and label management.
- Added "TODO" for everything in the release notes that needs updated after you run the automatic generation.
- Also added a bunch of things that can be inferred automatic, such as VS year, VS versions etc. This requires the occasional update of the tool, but better have to update the tool once every 2 years, then do manual like 8-9 over a few years.
 
Eventually, I'm considering merging the changelog/release notes generators into 1 tool as there is *a lot of overlap* between the 2 tools. One thing at a time though, once I am done with these improvements, I'll go and do that change.