### PR TITLE
Fix SDK patch tool when patching sdk 3.x

### DIFF
--- a/SDKPatchTool/patchUtil.ps1
+++ b/SDKPatchTool/patchUtil.ps1
@@ -13,6 +13,7 @@ function PatchNupkgs {
         [Parameter(Mandatory = $true)]
         [string]$nupkgsPath
     )
+
     #Create a temp folder for extracted files
     $tempExtractFolder = [System.IO.Path]::Combine($tempFolder, $nupkgID)
     $delimeter = [IO.Path]::DirectorySeparatorChar
@@ -53,7 +54,7 @@ function PatchNupkgs {
     
     $tfmFolderNetcoreapp21 =  Get-ChildItem -Path "$libPath$delimeter*" | Where-Object {$_.Name -like "netcoreapp2.1"}
    
-    if (($tfmFolderNet5 -ne $null) -Or ($tfmFolderNetcoreapp50 -ne $null)){
+    if (([int]($SDKVersion.Substring(0, 1)) -ge 5) -And (($tfmFolderNet5 -ne $null) -Or ($tfmFolderNetcoreapp50 -ne $null))){
         if ($tfmFolderNet5 -ne $null){
             $patchDll = Get-ChildItem -Path "$tfmFolderNet5$delimeter*" | Where-Object {$_.Name -like "*.dll"}
         }else{


### PR DESCRIPTION
Related to: https://github.com/NuGet/Home/issues/12314

The sdk patching tool could not handle patching sdk 3.x when NuGet inserts into both sdk 5.x and 3.x, it uses the dlls in netcoreapp5.0 folder of Nupkgs, instead of netstand2.1 folder.

This PR checks the version of sdk to be patched, if it's lower than 5, then do not use dlls in netcoreapp5.0 folder. 

