### PR TITLE
MakeTestCert:  add EKU's and RSA signature padding

### DIFF
--- a/MakeTestCert/.editorconfig
+++ b/MakeTestCert/.editorconfig
@@ -1,4 +1,7 @@
 ﻿[*.cs]
 
+# IDE0028: Simplify collection initialization
+dotnet_diagnostic.IDE0028.severity = none
+
 # IDE0063: Use simple 'using' statement
 csharp_prefer_simple_using_statement = false

--- a/MakeTestCert/MakeTestCert.csproj
+++ b/MakeTestCert/MakeTestCert.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>MakeTestCert</AssemblyName>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
     <LangVersion>preview</LangVersion>

--- a/MakeTestCert/Oids.cs
+++ b/MakeTestCert/Oids.cs
@@ -7,10 +7,14 @@ namespace MakeTestCert
 {
     internal static class Oids
     {
+        internal static readonly Oid ClientAuthenticationEku = new(DottedDecimalValues.ClientAuthenticationEku);
         internal static readonly Oid CodeSigningEku = new(DottedDecimalValues.CodeSigningEku);
+        internal static readonly Oid ServerAuthenticationEku = new(DottedDecimalValues.ServerAuthenticationEku);
 
         private static class DottedDecimalValues
         {
+            internal const string ServerAuthenticationEku = "1.3.6.1.5.5.7.3.1";
+            internal const string ClientAuthenticationEku = "1.3.6.1.5.5.7.3.2";
             internal const string CodeSigningEku = "1.3.6.1.5.5.7.3.3";
         }
     }

--- a/MakeTestCert/README.md
+++ b/MakeTestCert/README.md
@@ -7,35 +7,50 @@ MakeTestCert is a simple, cross-platform CLI for creating test code signing cert
 ```text
 Usage:  MakeTestCert.exe [option(s)]
 
-  Option                   Description                     Default
-  ------------------------ ------------------------------- -----------------
-  --key-algorithm, -ka     RSA or ECDSA                    RSA
-  --key-size, -ks          RSA key size in bits            3072
-  --named-curve, -nc       ECDSA named curve               nistP256
-  --not-after, -na         validity period end datetime    (now)
-  --not-before, -nb        validity period start datetime  (now + 2 hours)
-  --password, -p           PFX file password               (none)
-  --output-directory, -od  output directory path           .\
-  --subject, -s            certificate subject             CN=NuGet testing
-  --validity-period, -vp   validity period (in hours)      2
+  Option                        Description                    Default
+  ----------------------------- ------------------------------ -----------------
+  --extended-key-usage, -eku    extended key usage (EKU)       1.3.6.1.5.5.7.3.3
+  --hash-algorithm, -ha         signature hash algorithm       sha384
+                                (sha256, sha384, or sha512)
+  --key-algorithm, -ka          RSA or ECDSA                   RSA
+  --key-size, -ks               RSA key size in bits           3072
+  --named-curve, -nc            ECDSA named curve              nistP256
+  --not-after, -na              validity period end datetime   (now)
+  --not-before, -nb             validity period start datetime (now + 2 hours)
+  --output-directory, -od       output directory path          .\
+  --password, -p                PFX file password              (none)
+  --rsa-signature-padding, -rsp RSA signature padding          pkcs1
+                                (pkcs1 or pss)
+  --subject, -s                 certificate subject            CN=NuGet testing
+  --validity-period, -vp        validity period (in hours)     2
+
+Notes:
+
+  Common values for --extended-key-usage / -eku are defined in RFC 5280, section 4.2.1.12 and include:
+    1.3.6.1.5.5.7.3.1: Server Authentication
+    1.3.6.1.5.5.7.3.2: Client Authentication
+    1.3.6.1.5.5.7.3.3: Code Signing
 
 Examples:
 
   MakeTestCert.exe
-    Creates an RSA 3072-bit certificate valid for 2 hours from creation time.
+    Creates an RSA 3072-bit code signing certificate valid for 2 hours from creation time.
 
   MakeTestCert.exe -vp 8
-    Creates an RSA 3072-bit certificate valid for 8 hours from creation time.
+    Creates an RSA 3072-bit code signing certificate valid for 8 hours from creation time.
 
   MakeTestCert.exe -nb "2022-08-01 08:00" -na "2022-08-01 16:00"
-    Creates an RSA 3072-bit certificate valid for the specified local time
+    Creates an RSA 3072-bit code signing certificate valid for the specified local time
     period.
 
   MakeTestCert.exe -od .\certs
-    Creates an RSA 3072-bit certificate valid for 2 hours in the 'certs'
+    Creates an RSA 3072-bit code signing certificate valid for 2 hours in the 'certs'
     subdirectory.
 
   MakeTestCert.exe -ks 4096 -s CN=untrusted
-    Creates an RSA 4096-bit certificate valid for 2 hours with the subject
+    Creates an RSA 4096-bit code signing certificate valid for 2 hours with the subject
     'CN=untrusted'.
+
+  MakeTestCert.exe -eku 1.3.6.1.5.5.7.3.1 -eku 1.3.6.1.5.5.7.3.2
+    Creates an RSA 3072-bit TLS certificate valid for 2 hours from creation time.
 ```


### PR DESCRIPTION
Add to MakeTestCert:

* the ability to override the default EKU of code signing (e.g.:  to create a TLS certificate)
* the ability to override the default RSA signature padding