### PR TITLE
TrustTestCert:  add support for local machine certificate store

### DIFF
--- a/TrustTestCert/Program.cs
+++ b/TrustTestCert/Program.cs
@@ -10,6 +10,8 @@ namespace TrustTestCert
         private const int Success = 0;
         private const int Error = 1;
 
+        private static StoreLocation _certificateStoreLocation = StoreLocation.CurrentUser;
+
         private static int Main(string[] args)
         {
             try
@@ -54,9 +56,11 @@ namespace TrustTestCert
             X509Certificate2? certificate = null;
             DirectoryInfo? versionedSdkDirectory = null;
 
+            bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
             int argsCount = args.Length;
+            bool hasError = false;
 
-            for (var i = 1; i < argsCount - 1; i += 2)
+            for (var i = 1; !hasError && i < argsCount - 1; i += 2)
             {
                 string arg = args[i].ToLowerInvariant();
                 string nextArg = args[i + 1];
@@ -68,8 +72,25 @@ namespace TrustTestCert
                         certificate = new X509Certificate2(nextArg);
                         break;
 
+                    case "-csl":
+                    case "--certificate-store-location":
+                        if (!isWindows)
+                        {
+                            hasError = true;
+                            break;
+                        }
+
+                        _certificateStoreLocation = Enum.Parse<StoreLocation>(nextArg, ignoreCase: true);
+                        break;
+
                     case "-vsd":
                     case "--versioned-sdk-directory":
+                        if (isWindows)
+                        {
+                            hasError = true;
+                            break;
+                        }
+
                         versionedSdkDirectory = new DirectoryInfo(nextArg);
                         break;
 
@@ -80,10 +101,7 @@ namespace TrustTestCert
                 }
             }
 
-            bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
-
-            if (certificate is null ||
-                (isWindows != versionedSdkDirectory is null))
+            if (hasError || certificate is null)
             {
                 PrintHelp();
 
@@ -111,7 +129,7 @@ namespace TrustTestCert
                     {
                         if (isWindows)
                         {
-                            return AddTrust(certificate);
+                            return AddTrust(certificate, _certificateStoreLocation);
                         }
                         else
                         {
@@ -123,7 +141,7 @@ namespace TrustTestCert
                     {
                         if (isWindows)
                         {
-                            return RemoveTrust(certificate);
+                            return RemoveTrust(certificate, _certificateStoreLocation);
                         }
                         else
                         {
@@ -135,11 +153,11 @@ namespace TrustTestCert
             return Error;
         }
 
-        private static int AddTrust(X509Certificate2 certificate)
+        private static int AddTrust(X509Certificate2 certificate, StoreLocation storeLocation)
         {
             bool alreadyExists;
 
-            using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+            using (X509Store store = new(StoreName.Root, storeLocation))
             {
                 store.Open(OpenFlags.ReadWrite);
 
@@ -151,23 +169,25 @@ namespace TrustTestCert
                 }
             }
 
+            string storeLocationFriendlyName = GetFriendlyName(storeLocation);
+
             if (alreadyExists)
             {
-                Console.WriteLine("The certificate already exists in the current user's root store.");
+                Console.WriteLine($"The certificate already exists in the {storeLocationFriendlyName}'s root store.");
             }
             else
             {
-                using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+                using (X509Store store = new(StoreName.Root, storeLocation))
                 {
                     store.Open(OpenFlags.ReadOnly);
 
                     if (store.Certificates.Contains(certificate))
                     {
-                        Console.WriteLine("The certificate was added to the current user's root store.");
+                        Console.WriteLine($"The certificate was added to the {storeLocationFriendlyName}'s root store.");
                     }
                     else
                     {
-                        Console.Error.WriteLine("The certificate was not added to the current user's root store.");
+                        Console.Error.WriteLine($"The certificate was not added to the {storeLocationFriendlyName}'s root store.");
 
                         return Error;
                     }
@@ -204,11 +224,11 @@ namespace TrustTestCert
             return Success;
         }
 
-        private static int RemoveTrust(X509Certificate2 certificate)
+        private static int RemoveTrust(X509Certificate2 certificate, StoreLocation storeLocation)
         {
             bool alreadyExists;
 
-            using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+            using (X509Store store = new(StoreName.Root, storeLocation))
             {
                 store.Open(OpenFlags.ReadWrite);
 
@@ -220,25 +240,27 @@ namespace TrustTestCert
                 }
             }
 
+            string storeLocationFriendlyName = GetFriendlyName(storeLocation);
+
             if (alreadyExists)
             {
-                using (X509Store store = new(StoreName.Root, StoreLocation.CurrentUser))
+                using (X509Store store = new(StoreName.Root, storeLocation))
                 {
                     store.Open(OpenFlags.ReadOnly);
 
                     if (store.Certificates.Contains(certificate))
                     {
-                        Console.Error.WriteLine("The certificate was not removed from the current user's root store.");
+                        Console.Error.WriteLine($"The certificate was not removed from the {storeLocationFriendlyName}'s root store.");
 
                         return Error;
                     }
 
-                    Console.WriteLine("The certificate was removed from the current user's root store.");
+                    Console.WriteLine($"The certificate was removed from the {storeLocationFriendlyName}'s root store.");
                 }
             }
             else
             {
-                Console.WriteLine("The certificate was not present in the current user's root store.");
+                Console.WriteLine($"The certificate was not present in the {storeLocationFriendlyName}'s root store.");
             }
 
             return Success;
@@ -269,38 +291,57 @@ namespace TrustTestCert
             return Success;
         }
 
+        private static string GetFriendlyName(StoreLocation storeLocation)
+        {
+            return storeLocation switch
+            {
+                StoreLocation.CurrentUser => "current user",
+                StoreLocation.LocalMachine => "local machine",
+                _ => throw new ArgumentException(message: null, nameof(storeLocation))
+            };
+        }
+
         private static void PrintHelp()
         {
             FileInfo file = new(Environment.ProcessPath!);
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file.Name);
+            string storeLocationFriendlyName = GetFriendlyName(_certificateStoreLocation);
 
             Console.WriteLine($"Usage:  {file.Name} <add|remove> --certificate <CertificateFilePath> [option]");
             Console.WriteLine();
-            Console.WriteLine("  Option                           Description");
-            Console.WriteLine("  -------------------------------- -------------------------------------------");
-            Console.WriteLine($"  --versioned-sdk-directory, -vsd  The versioned .NET SDK root directory that ");
-            Console.WriteLine($"                                   contains trustedroots{Path.DirectorySeparatorChar}codesignctl.pem.");
-            Console.WriteLine("                                   On Windows, this option is never used.");
-            Console.WriteLine("                                   On Linux/macOS, this option is required.");
+            Console.WriteLine("  Option                              Description");
+            Console.WriteLine("  ----------------------------------- -------------------------------------------");
+            Console.WriteLine("  --certificate-store-location, -csl  The certificate store location, either");
+            Console.WriteLine("                                      CurrentUser or LocalMachine.");
+            Console.WriteLine("                                      On Windows, the default is CurrentUser,");
+            Console.WriteLine("                                      and LocalMachine requires elevation.");
+            Console.WriteLine("                                      On Linux/macOS, this option is never used.");
+            Console.WriteLine("  --versioned-sdk-directory, -vsd     The versioned .NET SDK root directory that ");
+            Console.WriteLine($"                                      contains trustedroots{Path.DirectorySeparatorChar}codesignctl.pem.");
+            Console.WriteLine("                                      On Windows, this option is never used.");
+            Console.WriteLine("                                      On Linux/macOS, this option is required.");
             Console.WriteLine("Examples:");
             Console.WriteLine();
             Console.WriteLine("  Windows:");
             Console.WriteLine($"    {fileNameWithoutExtension}.exe add -c .\\test.cer");
-            Console.WriteLine($"      Adds the certificate to the current user's root store.");
+            Console.WriteLine($"      Adds the certificate to the {storeLocationFriendlyName}'s root store.");
             Console.WriteLine();
             Console.WriteLine($"    {fileNameWithoutExtension}.exe add -c .\\test.pfx");
-            Console.WriteLine($"      Adds the certificate and its private key to the current user's root store.");
+            Console.WriteLine($"      Adds the certificate and its private key to the {storeLocationFriendlyName}'s root store.");
+            Console.WriteLine();
+            Console.WriteLine($"    {fileNameWithoutExtension}.exe add -c .\\test.cer -csl LocalMachine");
+            Console.WriteLine($"      Adds the certificate to the {GetFriendlyName(StoreLocation.LocalMachine)}'s root store.");
             Console.WriteLine();
             Console.WriteLine($"    {fileNameWithoutExtension}.exe remove -c .\\test.cer");
-            Console.WriteLine($"      Removes the certificate from the current user's root store.");
+            Console.WriteLine($"      Removes the certificate from the {storeLocationFriendlyName}'s root store.");
             Console.WriteLine();
             Console.WriteLine("  Linux/macOS:");
             Console.WriteLine($"    {fileNameWithoutExtension} add -c ./test.pem -vsd ~/dotnet/sdk/7.0.100");
-            Console.WriteLine($"      Adds the certificate to the specified .NET SDK's fallback certificate ");
+            Console.WriteLine("      Adds the certificate to the specified .NET SDK's fallback certificate ");
             Console.WriteLine("      bundle.");
             Console.WriteLine();
             Console.WriteLine($"    {fileNameWithoutExtension} remove -c ./test.pem -vsd ~/dotnet/sdk/7.0.100");
-            Console.WriteLine($"      Removes the certificate from the specified .NET SDK's fallback ");
+            Console.WriteLine("      Removes the certificate from the specified .NET SDK's fallback ");
             Console.WriteLine("      certificate bundle.");
         }
     }

--- a/TrustTestCert/README.md
+++ b/TrustTestCert/README.md
@@ -7,31 +7,39 @@ TrustTestCert is a simple, cross-platform CLI for adding and removing trust for 
 ```text
 Usage:  TrustTestCert.exe <add|remove> --certificate <CertificateFilePath> [option]
 
-  Option                           Description
-  -------------------------------- -------------------------------------------
-  --versioned-sdk-directory, -vsd  The versioned .NET SDK root directory that
-                                   contains trustedroots\codesignctl.pem.
-                                   On Windows, this option is never used.
-                                   On Linux/macOS, this option is required.
+  Option                              Description
+  ----------------------------------- -------------------------------------------
+  --certificate-store-location, -csl  The certificate store location, either
+                                      CurrentUser or LocalMachine.
+                                      On Windows, the default is CurrentUser,
+                                      and LocalMachine requires elevation.
+                                      On Linux/macOS, this option is never used.
+  --versioned-sdk-directory, -vsd     The versioned .NET SDK root directory that 
+                                      contains trustedroots\codesignctl.pem.
+                                      On Windows, this option is never used.
+                                      On Linux/macOS, this option is required.
 Examples:
 
   Windows:
     TrustTestCert.exe add -c .\test.cer
       Adds the certificate to the current user's root store.
-  
+
     TrustTestCert.exe add -c .\test.pfx
       Adds the certificate and its private key to the current user's root store.
+
+    TrustTestCert.exe add -c .\test.cer -csl LocalMachine
+      Adds the certificate to the local machine's root store.
 
     TrustTestCert.exe remove -c .\test.cer
       Removes the certificate from the current user's root store.
 
   Linux/macOS:
     TrustTestCert add -c ./test.pem -vsd ~/dotnet/sdk/7.0.100
-      Adds the certificate to the specified .NET SDK's fallback certificate
+      Adds the certificate to the specified .NET SDK's fallback certificate 
       bundle.
 
     TrustTestCert remove -c ./test.pem -vsd ~/dotnet/sdk/7.0.100
-      Removes the certificate from the specified .NET SDK's fallback
+      Removes the certificate from the specified .NET SDK's fallback 
       certificate bundle.
 ```
 

--- a/TrustTestCert/TrustTestCert.csproj
+++ b/TrustTestCert/TrustTestCert.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>TrustTestCert</AssemblyName>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
This change updates the TrustTestCert tool on Windows only to support adding/removing certificates to/from the local machine root store.  The default certificate store location is still current user, but the default can be overridden with either `--certificate-store-location LocalMachine` or `-csl LocalMachine`.

CC @v-luzh, @SueSu01