### PR TITLE
Custom Trace Parser for Restore EventSource Events

### DIFF
--- a/RestoreTraceParser/RestoreTraceParser.sln
+++ b/RestoreTraceParser/RestoreTraceParser.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34620.261
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RestoreTraceParser", "src\RestoreTraceParser.csproj", "{303DC893-5149-4ECF-AB2D-37267FBC9929}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RestoreTraceParserTests", "test\RestoreTraceParserTests.csproj", "{34CFD445-6053-4C00-A46A-7A557B491105}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{303DC893-5149-4ECF-AB2D-37267FBC9929}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{303DC893-5149-4ECF-AB2D-37267FBC9929}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{303DC893-5149-4ECF-AB2D-37267FBC9929}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{303DC893-5149-4ECF-AB2D-37267FBC9929}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34CFD445-6053-4C00-A46A-7A557B491105}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34CFD445-6053-4C00-A46A-7A557B491105}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34CFD445-6053-4C00-A46A-7A557B491105}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34CFD445-6053-4C00-A46A-7A557B491105}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A36C6B8D-EE74-4A23-A6A3-8A2C57ECCF36}
+	EndGlobalSection
+EndGlobal

--- a/RestoreTraceParser/src/GraphStats/GraphStats.cs
+++ b/RestoreTraceParser/src/GraphStats/GraphStats.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.IO;
+using Microsoft.Diagnostics.Tracing;
+
+namespace RestoreTraceParser
+{
+    public static class GraphStats
+    {
+        // Can be called from Main to generate statistics about the NuGet graph.
+        // Depends on event "Microsoft-NuGet/WalkAsyncTransitivePackage", which is a prototype
+        // event and not present in mainline builds.  The event is of the form:
+        //      Package (string)
+        //      TransitiveHitCount (int)
+        public static void Execute(string[] args)
+        {
+            PackageTable packageTable = new PackageTable();
+
+            string sourceDirectory = args[1];
+            string[] traceFiles = System.IO.Directory.GetFiles(sourceDirectory, "*.etl");
+            bool firstTrace = true;
+            foreach (string traceFile in traceFiles)
+            {
+                if (traceFile.EndsWith(".clrRundown.etl") || traceFile.EndsWith(".kernel.etl"))
+                {
+                    continue;
+                }
+
+                if (firstTrace)
+                {
+                    firstTrace = false;
+                }
+                else
+                {
+                    packageTable.IncrementRunIndex();
+                }
+                Console.WriteLine($"Processing {traceFile}");
+                ProcessTrace(traceFile, packageTable);
+            }
+
+            if (packageTable.AllRunsIdentical())
+            {
+                Console.WriteLine("All runs are identical.");
+            }
+            else
+            {
+                Console.WriteLine("Not all runs are identical.");
+            }
+
+            string outputPath = Path.Combine(sourceDirectory, "packageTable.csv");
+            using (StreamWriter writer = new StreamWriter(outputPath))
+            {
+                packageTable.PrintTable(writer);
+            }
+
+            Console.WriteLine($"Results written to {outputPath}.");
+        }
+
+        private static void ProcessTrace(string pathToTrace, PackageTable packageTable)
+        {
+            using (ETWTraceEventSource source = new ETWTraceEventSource(pathToTrace))
+            {
+                source.Dynamic.AddCallbackForProviderEvent("Microsoft-NuGet", "WalkAsyncTransitivePackage", (data) =>
+                {
+                    string package = data.PayloadString(0);
+                    int transitiveHitCount = (int)data.PayloadValue(1);
+
+                    packageTable.IncrementBy(package, transitiveHitCount);
+                });
+
+                source.Process();
+            }
+        }
+    }
+}

--- a/RestoreTraceParser/src/GraphStats/PackageTable.cs
+++ b/RestoreTraceParser/src/GraphStats/PackageTable.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace RestoreTraceParser
+{
+    public sealed class PackageTableEntry
+    {
+        private List<int> _nodeCountByRun;
+
+        public string LibraryName { get; }
+        public List<int> NodeCountByRun { get { return _nodeCountByRun; } }
+
+        public PackageTableEntry(string libraryName)
+        {
+            LibraryName = libraryName;
+            _nodeCountByRun = [0];
+        }
+
+        public void SetRunIndex(int index)
+        {
+            if (index >= _nodeCountByRun.Count)
+            {
+                for(int i = _nodeCountByRun.Count; i <= index; i++)
+                {
+                    _nodeCountByRun.Add(0);
+                }
+            }
+        }
+
+        public void Increment(int index, int count)
+        {
+            if(index >= _nodeCountByRun.Count)
+            {
+                SetRunIndex(index);
+            }
+            _nodeCountByRun[index] += count;
+        }
+
+        public int GetNodeCount(int index)
+        {
+            return _nodeCountByRun[index];
+        }
+    }
+
+    public sealed class PackageTable
+    {
+        private Dictionary<string, PackageTableEntry> _nodeCountByPackage = new Dictionary<string, PackageTableEntry>(StringComparer.OrdinalIgnoreCase);
+        private int _runIndex = 0;
+
+        public void IncrementBy(string libraryName, int count)
+        {
+            if (!_nodeCountByPackage.TryGetValue(libraryName, out PackageTableEntry entry))
+            {
+                entry = new PackageTableEntry(libraryName);
+                _nodeCountByPackage.Add(libraryName, entry);
+            }
+
+            entry.Increment(_runIndex, count);
+        }
+
+        public int IncrementRunIndex()
+        {
+            int prevIndex = _runIndex++;
+            for(int i=0; i<_nodeCountByPackage.Count; i++)
+            {
+                _nodeCountByPackage.Values
+                    .ElementAt(i)
+                    .SetRunIndex(_runIndex);
+            }
+
+            return prevIndex;
+        }
+
+        public int GetNodeCount(string libraryName, int index)
+        {
+            if (_nodeCountByPackage.TryGetValue(libraryName, out PackageTableEntry entry))
+            {
+                return entry.GetNodeCount(index);
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        public bool AllRunsIdentical()
+        {
+            bool ret = true;
+            foreach (var library in _nodeCountByPackage)
+            {
+                int firstCount = library.Value.NodeCountByRun[0];
+                foreach (var nodeCount in library.Value.NodeCountByRun)
+                {
+                    if (nodeCount != firstCount)
+                    {
+                        ret = false;
+                        Console.WriteLine($"Package with different node counts: {library.Key}");
+                    }
+                }
+            }
+
+            return ret;
+        }
+
+        public void PrintTable(TextWriter writer)
+        {
+            writer.WriteCsvCell("Library");
+            for (int i = 0; i <= _runIndex; i++)
+            {
+                writer.WriteCsvCell($"Run {i + 1}");
+            }
+            writer.WriteLine();
+
+            foreach (var library in _nodeCountByPackage)
+            {
+                writer.WriteCsvCell(library.Key);
+                for (int i = 0; i <= _runIndex; i++)
+                {
+                    writer.WriteCsvCell(library.Value.GetNodeCount(i));
+                }
+                writer.WriteLine();
+            }
+        }
+    }
+}

--- a/RestoreTraceParser/src/PhaseTracker/PhaseProject.cs
+++ b/RestoreTraceParser/src/PhaseTracker/PhaseProject.cs
@@ -1,0 +1,169 @@
+﻿using Microsoft.Diagnostics.Tracing;
+
+namespace RestoreTraceParser
+{
+    internal class PhaseProject
+    {
+        private double _restoreProjectStartTimeStamp;
+        private double _restoreProjectStopTimeStamp;
+
+        private double _calculateAndWriteDependencySpecStartTimeStamp;
+        private double _calculateAndWriteDependencySpecStopTimeStamp;
+
+        private double _createRestoreGraphStartTimeStamp;
+        private double _createRestoreGraphStopTimeStamp;
+
+        private double _buildAssetsFileStartTimeStamp;
+        private double _buildAssetsFileStopTimeStamp;
+
+        private double _commitAsyncStartTimeStamp;
+        private double _commitAsyncStopTimeStamp;
+
+        private double _writeCacheFileStartTimeStamp;
+        private double _writeCacheFileStopTimeStamp;
+
+        private double _writeDgSpecFileStartTimeStamp;
+        private double _writeDgSpecFileStopTimeStamp;
+
+        private double _writeLockFileStartTimeStamp;
+        private double _writeLockFileStopTimeStamp;
+
+        private double _writePackagesLockFileStartTimeStamp;
+        private double _writePackagesLockFileStopTimeStamp;
+
+        public double RestoreTime
+        {
+            get { return _restoreProjectStopTimeStamp - _restoreProjectStartTimeStamp; }
+        }
+
+        public double CalculateAndWriteDependencySpecTime
+        {
+            get { return _calculateAndWriteDependencySpecStopTimeStamp - _calculateAndWriteDependencySpecStartTimeStamp; }
+        }
+
+        public double CreateRestoreGraphTime
+        {
+            get { return _createRestoreGraphStopTimeStamp - _createRestoreGraphStartTimeStamp; }
+        }
+
+        public double BuildAssetsFileTime
+        {
+            get { return _buildAssetsFileStopTimeStamp - _buildAssetsFileStartTimeStamp; }
+        }
+
+        public double CommitAsyncTime
+        {
+            get { return _commitAsyncStopTimeStamp - _commitAsyncStartTimeStamp; }
+        }
+
+        public double WriteCacheFileTime
+        {
+            get { return _writeCacheFileStopTimeStamp - _writeCacheFileStartTimeStamp; }
+        }
+
+        public double WriteDgSpecFileTime
+        {
+            get { return _writeDgSpecFileStopTimeStamp - _writeDgSpecFileStartTimeStamp; }
+        }
+
+        public double WriteLockFileTime
+        {
+            get { return _writeLockFileStopTimeStamp - _writeLockFileStartTimeStamp; }
+        }
+
+        public double WritePackagesLockFileTime
+        {
+            get { return _writePackagesLockFileStopTimeStamp - _writePackagesLockFileStartTimeStamp; }
+        }
+
+        public void OnRestoreProjectStart(TraceEvent data)
+        {
+            _restoreProjectStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnRestoreProjectStop(TraceEvent data)
+        {
+            _restoreProjectStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnCalculateAndWriteDependencySpecStart(TraceEvent data)
+        {
+            _calculateAndWriteDependencySpecStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnCalculateAndWriteDependencySpecStop(TraceEvent data)
+        {
+            _calculateAndWriteDependencySpecStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnCreateRestoreGraphStart(TraceEvent data)
+        {
+            _createRestoreGraphStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnCreateRestoreGraphStop(TraceEvent data)
+        {
+            _createRestoreGraphStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnBuildAssetsFileStart(TraceEvent data)
+        {
+            _buildAssetsFileStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnBuildAssetsFileStop(TraceEvent data)
+        {
+            _buildAssetsFileStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnCommitAsyncStart(TraceEvent data)
+        {
+            _commitAsyncStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnCommitAsyncStop(TraceEvent data)
+        {
+            _commitAsyncStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWriteCacheFileStart(TraceEvent data)
+        {
+            _writeCacheFileStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWriteCacheFileStop(TraceEvent data)
+        {
+            _writeCacheFileStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWriteDgSpecFileStart(TraceEvent data)
+        {
+            _writeDgSpecFileStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWriteDgSpecFileStop(TraceEvent data)
+        {
+            _writeDgSpecFileStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWriteLockFileStart(TraceEvent data)
+        {
+            _writeLockFileStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWriteLockFileStop(TraceEvent data)
+        {
+            _writeLockFileStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWritePackagesLockFileStart(TraceEvent data)
+        {
+            _writePackagesLockFileStartTimeStamp = data.TimeStampRelativeMSec;
+        }
+
+        public void OnWritePackagesLockFileStop(TraceEvent data)
+        {
+            _writePackagesLockFileStopTimeStamp = data.TimeStampRelativeMSec;
+        }
+    }
+}

--- a/RestoreTraceParser/src/PhaseTracker/PhaseTracker.cs
+++ b/RestoreTraceParser/src/PhaseTracker/PhaseTracker.cs
@@ -1,0 +1,328 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+
+namespace RestoreTraceParser
+{
+    public static class PhaseTracker
+    {
+        private const string ProcessName = "NuGet.Build.Tasks.Console";
+        private const string DisableParallelismArgument = "DisableParallel=True";
+        private const string EventSourceName = "Microsoft-NuGet";
+        private static Dictionary<string, PhaseProject> _phaseList = new Dictionary<string, PhaseProject>();
+        private static Dictionary<string, PhaseProject> _directoryToProject = new Dictionary<string, PhaseProject>();
+        private static Dictionary<int, PhaseProject> _threadToProject = new Dictionary<int, PhaseProject>();
+
+        private static int _processId;
+        private static double _processStartTimeStamp;
+        private static double _processStopTimeStamp;
+        private static double _lastNuGetEventTimeStamp;
+
+        private static UnTrackedTimeTracker _untrackedTimeTracker;
+
+        public static void Execute(string[] args)
+        {
+            string pathToTrace = args[1];
+            ProcessTrace(pathToTrace);
+            string outputPath = Path.Combine(Path.GetDirectoryName(pathToTrace), "restorePhases.csv");
+            using (TextWriter writer = new StreamWriter(outputPath))
+            {
+                WriteResults(writer);
+            }
+
+            Console.WriteLine($"Process Wall Clock (ms): {(_processStopTimeStamp - _processStartTimeStamp).ToString("#.##")}");
+            Console.WriteLine($"Time from last NuGet event: {(_processStopTimeStamp - _lastNuGetEventTimeStamp).ToString("#.##")}");
+
+            if (_untrackedTimeTracker != null)
+            {
+                Console.WriteLine("Total Untracked Time: (ms) " + _untrackedTimeTracker.TotalUntrackedTime.ToString("#.##"));
+                _untrackedTimeTracker.WriteRanges(Console.Out);
+            }
+
+            Console.WriteLine("Phase timing written to " + outputPath);
+        }
+
+        private static void ProcessTrace(string pathToTrace)
+        {
+            using (ETWTraceEventSource source = new ETWTraceEventSource(pathToTrace))
+            {
+                source.Kernel.ProcessStart += delegate (ProcessTraceData data)
+                {
+                    if (ProcessName.Equals(data.ProcessName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _processStartTimeStamp = data.TimeStampRelativeMSec;
+                        _processId = data.ProcessID;
+                        if(data.CommandLine.Contains(DisableParallelismArgument))
+                        {
+                            _untrackedTimeTracker = new UnTrackedTimeTracker();
+                        }
+                    }
+                };
+
+                source.Kernel.ProcessStop += delegate (ProcessTraceData data)
+                {
+                    if (data.ProcessID == _processId)
+                    {
+                        _processStopTimeStamp = data.TimeStampRelativeMSec;
+                    }
+                };
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreRunner/RestoreProject/Start", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    PhaseProject project = new PhaseProject();
+                    _phaseList.Add(projectName, project);
+                    _directoryToProject.Add(ProjectDirectoryFromProjectPath(projectName), project);
+                    project.OnRestoreProjectStart(data);
+
+                    _untrackedTimeTracker?.OnUnTrackedTimeStop(data.TimeStampRelativeMSec, "Non-Restore Time");
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreRunner/RestoreProject/Stop", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnRestoreProjectStop(data);
+                    }
+
+                    _untrackedTimeTracker?.OnUnTrackedTimeStart(data.TimeStampRelativeMSec);
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreCommand/CalcNoOpRestore/Start", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        _threadToProject[data.ThreadID] = value;
+                        value.OnCalculateAndWriteDependencySpecStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreCommand/CalcNoOpRestore/Stop", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnCalculateAndWriteDependencySpecStop(data);
+                    }
+
+                    // Clear the thread mapping to PhaseProject.
+                    if (_threadToProject.TryGetValue(data.ThreadID, out PhaseProject project))
+                    {
+                        Debug.Assert(project == value);
+                        _threadToProject.Remove(data.ThreadID);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreCommand/BuildRestoreGraph/Start", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnCreateRestoreGraphStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreCommand/BuildRestoreGraph/Stop", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnCreateRestoreGraphStop(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreCommand/BuildAssetsFile/Start", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnBuildAssetsFileStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreCommand/BuildAssetsFile/Stop", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnBuildAssetsFileStop(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreRunner/CommitAsync/Start", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnCommitAsyncStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreRunner/CommitAsync/Stop", (data) =>
+                {
+                    string projectName = data.PayloadString(0);
+
+                    if (_phaseList.TryGetValue(projectName, out PhaseProject value))
+                    {
+                        value.OnCommitAsyncStop(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WriteCacheFile/Start", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWriteCacheFileStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WriteCacheFile/Stop", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWriteCacheFileStop(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WriteDgSpecFile/Start", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWriteDgSpecFileStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WriteDgSpecFile/Stop", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWriteDgSpecFileStop(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WriteAssetsFile/Start", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWriteLockFileStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WriteAssetsFile/Stop", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWriteLockFileStop(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WritePackagesLockFile/Start", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWritePackagesLockFileStart(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, "RestoreResult/WritePackagesLockFile/Stop", (data) =>
+                {
+                    string filePath = data.PayloadString(0);
+                    string projectPath = ProjectDirectoryFromOutputFile(filePath);
+
+                    if (_directoryToProject.TryGetValue(projectPath, out PhaseProject value))
+                    {
+                        value.OnWritePackagesLockFileStop(data);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(EventSourceName, null, (data) =>
+                {
+                    _lastNuGetEventTimeStamp = data.TimeStampRelativeMSec;
+                });
+
+                source.Process();
+            }
+        }
+
+        private static string ProjectDirectoryFromProjectPath(string projectPath)
+        {
+            return Path.GetDirectoryName(projectPath);
+        }
+
+        private static string ProjectDirectoryFromOutputFile(string outputFilePath)
+        {
+            string directoryName = Path.GetDirectoryName(outputFilePath);
+            string directoryNameOnly = Path.GetFileName(directoryName);
+            if(directoryNameOnly.Equals(".pkgrefgen", StringComparison.OrdinalIgnoreCase))
+            {
+                directoryName = Path.GetDirectoryName(directoryName);
+            }
+            return directoryName;
+        }
+
+        private static void WriteResults(TextWriter writer)
+        {
+            writer.WriteCsvCell("Project");
+            writer.WriteCsvCell("Restore Time (ms)");
+            writer.WriteCsvCell("DependencySpec Time (ms)");
+            writer.WriteCsvCell("CreateRestoreGraph Time (ms)");
+            writer.WriteCsvCell("BuildAssetsFile Time (ms)");
+            writer.WriteCsvCell("CommitAsync Time (ms)");
+            writer.WriteCsvCell("CacheFile Write Time (ms)");
+            writer.WriteCsvCell("DgSpecFile Write Time (ms)");
+            writer.WriteCsvCell("LockFile Write Time (ms)");
+            writer.WriteCsvCell("PackagesLockFile Write Time (ms)");
+            writer.WriteLine();
+
+            foreach (KeyValuePair<string, PhaseProject> pair in _phaseList)
+            {
+                writer.WriteCsvCell(pair.Key);
+                writer.WriteCsvCell(pair.Value.RestoreTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.CalculateAndWriteDependencySpecTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.CreateRestoreGraphTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.BuildAssetsFileTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.CommitAsyncTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.WriteCacheFileTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.WriteDgSpecFileTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.WriteLockFileTime.ToString("#.##"));
+                writer.WriteCsvCell(pair.Value.WritePackagesLockFileTime.ToString("#.####"));
+                writer.WriteLine();
+            }
+        }
+    }
+}

--- a/RestoreTraceParser/src/PhaseTracker/UnTrackedTimeTracker.cs
+++ b/RestoreTraceParser/src/PhaseTracker/UnTrackedTimeTracker.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace RestoreTraceParser
+{
+    internal class UnTrackedTimeTracker
+    {
+        private double _untrackedTimeStampStart = -1.0;
+        private List<(double timeInMilliseconds, string description)> _untrackedTimeRanges = new List<(double, string)>();
+
+        public void OnUnTrackedTimeStart(double timeStamp)
+        {
+            _untrackedTimeStampStart = timeStamp;
+        }
+
+        public void OnUnTrackedTimeStop(double timeStamp, string description)
+        {
+            if (_untrackedTimeStampStart == -1.0)
+            {
+                return;
+            }
+
+            _untrackedTimeRanges.Add((timeStamp - _untrackedTimeStampStart, description));
+            _untrackedTimeStampStart = -1.0;
+        }
+
+        public double TotalUntrackedTime
+        {
+            get
+            {
+                double total = 0.0;
+                foreach (var range in _untrackedTimeRanges)
+                {
+                    total += range.timeInMilliseconds;
+                }
+
+                return total;
+            }
+        }
+
+        public void WriteRanges(TextWriter writer)
+        {
+            writer.WriteCsvCell("Time (ms)");
+            writer.WriteCsvCell("Description");
+            writer.WriteLine();
+
+            foreach (var range in _untrackedTimeRanges)
+            {
+                writer.WriteCsvCell(range.timeInMilliseconds.ToString("#.##"));
+                writer.WriteCsvCell(range.description);
+                writer.WriteLine();
+            }
+        }
+    }
+}

--- a/RestoreTraceParser/src/Program.cs
+++ b/RestoreTraceParser/src/Program.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace RestoreTraceParser
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            if(args.Length != 2)
+            {
+                Console.WriteLine("Usage: RestoreTraceParser <action> <path to trace files>");
+                Console.WriteLine("Valid actions:");
+                Console.WriteLine("\tpt: Breaks down the total restore time by project and phase.");
+                Console.WriteLine("\tgs: Provides statistics about the graph produced by RemoteDependencyWalker.");
+                return;
+            }
+
+            if (args[0].Equals("pt"))
+            {
+                PhaseTracker.Execute(args);
+            }
+            else if (args[0].Equals("gs"))
+            {
+                GraphStats.Execute(args);
+            }
+        }
+    }
+}

--- a/RestoreTraceParser/src/RestoreTraceParser.csproj
+++ b/RestoreTraceParser/src/RestoreTraceParser.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" />
+  </ItemGroup>
+
+</Project>

--- a/RestoreTraceParser/src/Utilities/TextWriterExtensions.cs
+++ b/RestoreTraceParser/src/Utilities/TextWriterExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+
+namespace RestoreTraceParser
+{
+    public static class TextWriterExtensions
+    {
+        public static void WriteCsvCell<T>(this TextWriter writer, T value)
+        {
+            if (value == null)
+            {
+                writer.Write(",");
+            }
+
+            string str = value.ToString();
+            if (str.Contains(",") || str.Contains("\"") || str.Contains("\n"))
+            {
+                writer.Write("\"" + str.Replace("\"", "\"\"") + "\"");
+            }
+            else
+            {
+                writer.Write(str);
+            }
+            writer.Write(",");
+        }
+    }
+}

--- a/RestoreTraceParser/test/PackageTableTests.cs
+++ b/RestoreTraceParser/test/PackageTableTests.cs
@@ -1,0 +1,59 @@
+using RestoreTraceParser;
+
+namespace RestoreTraceParserTests
+{
+    public class PackageTableTests
+    {
+        [Fact]
+        public void SingleRun()
+        {
+            PackageTable table = new PackageTable();
+            table.IncrementBy("A", 1);
+            table.IncrementBy("B", 1);
+            table.IncrementBy("A", 1);
+            table.IncrementBy("C", 1);
+            table.IncrementBy("B", 1);
+            table.IncrementBy("A", 1);
+
+            int prevIndex = table.IncrementRunIndex();
+
+            Assert.Equal(3, table.GetNodeCount("A", prevIndex));
+            Assert.Equal(2, table.GetNodeCount("B", prevIndex));
+            Assert.Equal(1, table.GetNodeCount("C", prevIndex));
+        }
+
+        [Fact]
+        public void TwoRuns()
+        {
+            PackageTable table = new PackageTable();
+            table.IncrementBy("A", 1);
+            table.IncrementBy("B", 1);
+            table.IncrementBy("A", 1);
+            table.IncrementBy("C", 1);
+            table.IncrementBy("B", 1);
+            table.IncrementBy("A", 1);
+
+            int firstIndex = table.IncrementRunIndex();
+
+            table.IncrementBy("D", 1);
+            table.IncrementBy("E", 1);
+            table.IncrementBy("F", 1);
+            table.IncrementBy("E", 1);
+            table.IncrementBy("D", 1);
+            table.IncrementBy("F", 3);
+
+            int secondIndex = table.IncrementRunIndex();
+
+            Assert.Equal(3, table.GetNodeCount("A", firstIndex));
+            Assert.Equal(2, table.GetNodeCount("B", firstIndex));
+            Assert.Equal(1, table.GetNodeCount("C", firstIndex));
+
+            Assert.Equal(2, table.GetNodeCount("D", secondIndex));
+            Assert.Equal(2, table.GetNodeCount("E", secondIndex));
+            Assert.Equal(4, table.GetNodeCount("F", secondIndex));
+            Assert.Equal(0, table.GetNodeCount("A", secondIndex));
+            Assert.Equal(0, table.GetNodeCount("B", secondIndex));
+            Assert.Equal(0, table.GetNodeCount("C", secondIndex));
+        }
+    }
+}

--- a/RestoreTraceParser/test/RestoreTraceParserTests.csproj
+++ b/RestoreTraceParser/test/RestoreTraceParserTests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="..\src\RestoreTraceParser.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Takes ETW traces of NuGet restore and produces the following reports:

 - A comparison of the breakdown of nodes produced by the `RemoteDependencyWalker`.
 - A breakdown of coarse restore cost of each input project.

Run the app with no command line arguments for the `usage` message.

@jeffkl, @bwadswor