### PR TITLE
Fix 0 bufferSize error with CI Reliability report

### DIFF
--- a/GithubIssueTagger/Reports/CiReliability/CiReliabilityReport.cs
+++ b/GithubIssueTagger/Reports/CiReliability/CiReliabilityReport.cs
@@ -303,7 +303,7 @@ Build
             int failedBuildsOnlyBecauseOfApex = data.FailedBuilds.Where(b => b.Details?.Count == 1 && b.Details[0].Job == "Apex Test Execution").Count();
             float reliabilityIgnoringApex = (data.TotalBuilds - data.FailedBuilds.Count + failedBuildsOnlyBecauseOfApex) * 100.0f / data.TotalBuilds;
 
-            using var sw = new StreamWriter(outputFileStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), failedBuildsOnlyBecauseOfApex);
+            using var sw = new StreamWriter(outputFileStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
             sw.WriteLine("# NuGet.Client CI Reliability " + data.SprintName);
             sw.WriteLine();
             sw.WriteLine("[NuGet.Client-PR dev branch builds](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=8118&branchFilter=101196%2C101196%2C101196%2C101196%2C101196)");


### PR DESCRIPTION
This int can be 0 which is not appropriate for a bufferSize.