### PR TITLE
GitbutIssueTagger should roll forward to newer runtimes

### DIFF
--- a/GithubIssueTagger/GithubIssueTagger.csproj
+++ b/GithubIssueTagger/GithubIssueTagger.csproj
@@ -14,6 +14,7 @@
     <PackageId>NuGet.Internal.GithubIssueTagger</PackageId>
     <Version>$([System.DateTime]::Now.ToString('yyyy.MM.dd'))</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We have a GitHub Actions workflow that runs this tool every day for the 'Icebox Watcher" report. It was failing because the tool was built against an older version of .NET.  In the future when the version of .NET on the CI agent is newer than what this tool was built against, hopefully the roll forward should allow it to keep working.