### PR TITLE
Make IceBox watcher report more reliable

### DIFF
--- a/GithubIssueTagger/GraphQL/GitHubGraphQLClient.cs
+++ b/GithubIssueTagger/GraphQL/GitHubGraphQLClient.cs
@@ -34,6 +34,8 @@ namespace GithubIssueTagger.GraphQL
         {
             using var httpResponse = await HttpClient.PostAsJsonAsync(requestUri: (string?)null, request);
 
+            Console.WriteLine(httpResponse);
+
             var rateLimitLimit = httpResponse.Headers.GetValues("X-RateLimit-Limit").SingleOrDefault();
             var rateLimitRemaining = httpResponse.Headers.GetValues("X-RateLimit-Remaining").SingleOrDefault();
             var rateLimitReset = long.Parse(httpResponse.Headers.GetValues("X-RateLimit-Reset").Single());

--- a/GithubIssueTagger/GraphQL/GitHubGraphQLClient.cs
+++ b/GithubIssueTagger/GraphQL/GitHubGraphQLClient.cs
@@ -73,13 +73,17 @@ namespace GithubIssueTagger.GraphQL
                             Console.WriteLine(body);
                         }
 
-                        if (httpResponse.Headers.TryGetValues("Retry-After", out var values))
+                        if (httpResponse.Headers?.RetryAfter?.Date != null)
                         {
-                            var retryAfterHeader = values.FirstOrDefault();
-                            if (retryAfterHeader != null && int.TryParse(retryAfterHeader, out var retryAfterSeconds))
+                            retryAfter = httpResponse.Headers.RetryAfter.Date.Value - DateTime.UtcNow;
+                            if (retryAfter < TimeSpan.Zero)
                             {
-                                retryAfter = TimeSpan.FromSeconds(retryAfterSeconds);
+                                retryAfter = delay;
                             }
+                        }
+                        else if (httpResponse.Headers?.RetryAfter?.Delta != null)
+                        {
+                            retryAfter = httpResponse.Headers.RetryAfter.Delta.Value;
                         }
 
                         httpResponse.Dispose();

--- a/GithubIssueTagger/GraphQL/GitHubGraphQLClient.cs
+++ b/GithubIssueTagger/GraphQL/GitHubGraphQLClient.cs
@@ -67,6 +67,12 @@ namespace GithubIssueTagger.GraphQL
                     {
                         Console.WriteLine(httpResponse);
 
+                        if (httpResponse.Content.Headers.ContentLength < 2000)
+                        {
+                            var body = await httpResponse.Content.ReadAsStringAsync();
+                            Console.WriteLine(body);
+                        }
+
                         if (httpResponse.Headers.TryGetValues("Retry-After", out var values))
                         {
                             var retryAfterHeader = values.FirstOrDefault();

--- a/GithubIssueTagger/Reports/IceBox/IceBoxResource.resx
+++ b/GithubIssueTagger/Reports/IceBox/IceBoxResource.resx
@@ -119,15 +119,15 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="AddLabelToIssue" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>addlabeltoissue.graphql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>AddLabelToIssue.graphql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="GetIssues" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>GetIssues.graphql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="GetLabeledEvents" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>getlabeledevents.graphql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>GetLabeledEvents.graphql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="GetLabelId" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>getlabelid.graphql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>GetLabelId.graphql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
 </root>


### PR DESCRIPTION
* Fix IceBoxResource.resx, so it can build on Linux
* Retry failed HTTP requests up to 5 times
* When a failed response has a `Retry-After` header, respect the duration
* Output to the console the failed HTTP response headers and body, so we can see what the failure is


Turns out the errors we were seeing were reaching github's [secondary rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits)