### PR TITLE
[TEST] Testing an issue triage bot

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -75,21 +75,21 @@ configuration:
     scheduledSearches:
       - description: search for issues that are waitingForCustomer and haven't got a response
         frequencies:
-          - daily:
-              time: 20:40
+          - hourly:
+              hour: 1
         filters:
           - isOpen
           - hasLabel:
               label: waitingForCustomer
           - noActivitySince:
-              minutes: 3
+              hours: 1
         actions:
           - addLabel:
               label: stale
       - description: close issues that are waitingForCustomer + stale for too long
         frequencies:
           - daily:
-              time: 20:40
+              time: 20:45
         filters:
           - isOpen
           - hasLabel:
@@ -97,7 +97,7 @@ configuration:
           - hasLabel:
               label: stale
           - noActivitySince:
-              minutes: 3
+              days: 1
         actions:
           - closeIssue
           - addReply:
@@ -105,11 +105,11 @@ configuration:
       - description: close issues that have not received any activity in 18 months
         frequencies:
           - daily:
-              time: 20:40
+              time: 20:45
         filters:
           - isOpen
           - noActivitySince:
-              minutes: 3
+              days: 1
           - hasLabel:
               label: triageTest
         actions:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,0 +1,122 @@
+name: Issue Triage
+description: Assign label to new issues without a label
+resource: repository
+disabled: false
+
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Check if a Type label is assigned to new issues
+        triggerOnOwnActions: false
+        if:
+          - payloadType: Issues
+          - and:
+              - isOpen
+              - not:
+                  - or: 
+                      - hasLabel:
+                          label: Bug
+                      - hasLabel:
+                          label: Feature
+                      - hasLabel:
+                          label: SupportRequest
+        then:
+          - addReply:
+              reply: "${issueAuthor}, please add a Bug/Feature/SupportRequest label as applicable."
+          - addLabel:
+              label: waitingForCustomer
+          - addLabel:
+              label: untriaged
+      - description: Update issue if Type label was assigned # removes waitingForCustomer + untriaged if someone assigns a type label
+        triggerOnOwnActions: false
+        if: 
+          - payloadType: Issues
+          - and:
+            - isOpen
+            - or: 
+              - labelAdded:
+                  label: Bug
+              - labelAdded:
+                  label: Feature
+              - labelAdded:
+                  label: SupportRequest
+        then:
+          - if: 
+              - hasLabel:
+                  label: untriaged
+            then:
+              - removeLabel:
+                  label: untriaged
+          - if: 
+              - not:
+                  - hasLabel:
+                      label: triaged
+            then:
+              - addLabel:
+                  label: triaged
+          - if:
+              - hasLabel:
+                label: waitingForCustomer
+            then:
+              - removeLabel:
+                  label: waitingForCustomer
+      - description: Update issues that had recent activity
+        triggerOnOwnActions: false
+        if:
+          - payloadType: Issues
+          - and:
+              - isOpen
+              - isAction::
+                  action: Issue_Comment # create or update (applies to issue description too?)
+        then:
+          - if:
+              - hasLabel:
+                  label: stale
+            then:
+              - removeLabel:
+                  label: stale
+    scheduledSearches:
+      - description: search for issues that are waitingForCustomer and haven't got a response
+        frequencies:
+          - weekday:
+            - day: Monday
+            - time: 06:00
+        filters:
+          - isOpen
+          - hasLabel:
+              label: waitingForCustomer
+          - noActivitySince:
+              days: 7
+        actions:
+          - addLabel:
+              label: stale
+      - description: close issues that are waitingForCustomer + stale for too long
+        frequencies:
+          - weekday:
+            - day: Monday
+            - time: 06:00
+        filters:
+          - isOpen
+          - hasLabel:
+              label: waitingForCustomer
+          - hasLabel:
+              label: stale
+          - noActivitySince:
+              days: 7
+        actions:
+          - closeIssue
+          - addReply:
+              reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."
+      - description: close issues that have not received any activity in 18 months
+        frequencies:
+          - weekday:
+            - day: Monday
+            - time: 06:00
+        filters:
+          - isOpen
+          - noActivitySince:
+              days: 540
+        actions:
+          - closeIssue
+          - addReply:
+              reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -55,7 +55,7 @@ configuration:
                   label: triaged
           - if:
               - hasLabel:
-                label: waitingForCustomer
+                  label: waitingForCustomer
             then:
               - removeLabel:
                   label: waitingForCustomer

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -31,15 +31,14 @@ configuration:
         triggerOnOwnActions: false
         if: 
           - payloadType: Issues
-          - and:
-            - isOpen
-            - or: 
-              - labelAdded:
-                  label: Bug
-              - labelAdded:
-                  label: Feature
-              - labelAdded:
-                  label: SupportRequest
+          - isOpen
+          - or: 
+            - labelAdded:
+                label: Bug
+            - labelAdded:
+                label: Feature
+            - labelAdded:
+                label: SupportRequest
         then:
           - if: 
               - hasLabel:
@@ -49,8 +48,8 @@ configuration:
                   label: untriaged
           - if: 
               - not:
-                  - hasLabel:
-                      label: triaged
+                  hasLabel:
+                    label: triaged
             then:
               - addLabel:
                   label: triaged

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -13,13 +13,13 @@ configuration:
           - and:
               - isOpen
               - not:
-                  - or: 
-                      - hasLabel:
-                          label: Bug
-                      - hasLabel:
-                          label: Feature
-                      - hasLabel:
-                          label: SupportRequest
+                  or: 
+                    - hasLabel:
+                        label: Bug
+                    - hasLabel:
+                        label: Feature
+                    - hasLabel:
+                        label: SupportRequest
         then:
           - addReply:
               reply: "${issueAuthor}, please add a Bug/Feature/SupportRequest label as applicable."

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -10,16 +10,15 @@ configuration:
         triggerOnOwnActions: false
         if:
           - payloadType: Issues
-          - and:
-              - isOpen
-              - not:
-                  or: 
-                    - hasLabel:
-                        label: Bug
-                    - hasLabel:
-                        label: Feature
-                    - hasLabel:
-                        label: SupportRequest
+          - isOpen
+          - not:
+              or: 
+                - hasLabel:
+                    label: Bug
+                - hasLabel:
+                    label: Feature
+                - hasLabel:
+                    label: SupportRequest
         then:
           - addReply:
               reply: "${issueAuthor}, please add a Bug/Feature/SupportRequest label as applicable."
@@ -63,10 +62,9 @@ configuration:
         triggerOnOwnActions: false
         if:
           - payloadType: Issues
-          - and:
-              - isOpen
-              - isAction::
-                  action: Issue_Comment # create or update (applies to issue description too?)
+          - isOpen
+          - isAction:
+              action: Issue_Comment # create or update (applies to issue description too?)
         then:
           - if:
               - hasLabel:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -75,8 +75,8 @@ configuration:
     scheduledSearches:
       - description: search for issues that are waitingForCustomer and haven't got a response
         frequencies:
-          - hourly:
-              hour: 0.02
+          - daily:
+              time: 20:40
         filters:
           - isOpen
           - hasLabel:
@@ -88,8 +88,8 @@ configuration:
               label: stale
       - description: close issues that are waitingForCustomer + stale for too long
         frequencies:
-          - hourly:
-              hour: 0.02
+          - daily:
+              time: 20:40
         filters:
           - isOpen
           - hasLabel:
@@ -104,8 +104,8 @@ configuration:
               reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."
       - description: close issues that have not received any activity in 18 months
         frequencies:
-          - hourly:
-              hour: 0.02
+          - daily:
+              time: 20:40
         filters:
           - isOpen
           - noActivitySince:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -82,7 +82,7 @@ configuration:
           - hasLabel:
               label: waitingForCustomer
           - noActivitySince:
-              hours: 1
+              days: 1
         actions:
           - addLabel:
               label: stale

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -75,23 +75,21 @@ configuration:
     scheduledSearches:
       - description: search for issues that are waitingForCustomer and haven't got a response
         frequencies:
-          - weekday:
-            - day: Monday
-            - time: 06:00
+          - hourly:
+              hour: 0.02
         filters:
           - isOpen
           - hasLabel:
               label: waitingForCustomer
           - noActivitySince:
-              days: 7
+              minutes: 3
         actions:
           - addLabel:
               label: stale
       - description: close issues that are waitingForCustomer + stale for too long
         frequencies:
-          - weekday:
-            - day: Monday
-            - time: 06:00
+          - hourly:
+              hour: 0.02
         filters:
           - isOpen
           - hasLabel:
@@ -99,20 +97,21 @@ configuration:
           - hasLabel:
               label: stale
           - noActivitySince:
-              days: 7
+              minutes: 3
         actions:
           - closeIssue
           - addReply:
               reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."
       - description: close issues that have not received any activity in 18 months
         frequencies:
-          - weekday:
-            - day: Monday
-            - time: 06:00
+          - hourly:
+              hour: 0.02
         filters:
           - isOpen
           - noActivitySince:
-              days: 540
+              minutes: 3
+          - hasLabel:
+              label: triageTest
         actions:
           - closeIssue
           - addReply:


### PR DESCRIPTION
We want to add a github policies file to automate issue triage for the VSM Github repo, and were looking to test it in this repo first (few active issues, low activity).

Once we've completed our test, we'll clean up our changes and remove this file from here.