### PR TITLE
Use default LCI Comment DirPath in LocalizationValidator

### DIFF
--- a/NuGetBuildValidators/NuGetValidator.Localization/LocalizationValidator.cs
+++ b/NuGetBuildValidators/NuGetValidator.Localization/LocalizationValidator.cs
@@ -315,6 +315,7 @@ namespace NuGetValidator.Localization
 
         private static void CompareAllStrings(string firstDll, string secondDll, string lciCommentDirPath)
         {
+            lciCommentDirPath = lciCommentDirPath ?? Path.GetDirectoryName(firstDll);
             var lciFilePath = Path.Combine(lciCommentDirPath, Path.GetFileName(firstDll) + ".lci");
             XElement lciFile = null;
             if (File.Exists(lciFilePath))

--- a/NuGetBuildValidators/NuGetValidator/Properties/launchSettings.json
+++ b/NuGetBuildValidators/NuGetValidator/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NuGetValidator": {
       "commandName": "Project",
-      "commandLineArgs": "artifact --files \"F:\\validation\\NuGetValidators.Artifact\\extracted\\Microsoft.Web.XmlTransform.dll\" --output-path E:\\nuget.client\\artifacts\\ArtifactValidation\\artifacts"
+      "commandLineArgs": "localization --vsix --vsix-path C:\\NuGet.Client\\artifacts\\VS15\\NuGet.Tools.vsix --vsix-extract-path C:\\Temp\\VSIXExtract\\ --output-path C:\\Temp\\VSIXOutput\\"
     }
   }
 }


### PR DESCRIPTION
Instead of a NullReferenceException when `lciCommentDirPath` is null, default it to the same directory the first DLL is in.
The result is the logic can continue and show warnings that each lci file does not exist.
The resulting output file contains

`"LciDirectory": null,`
and
`"LciFilesFound": [],`